### PR TITLE
Time sync config

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,10 +133,14 @@ ubuntu1804cis_time_synchronization: chrony
 ubuntu1804cis_time_Synchronization: ntp
 
 ubuntu1804cis_time_synchronization_servers:
-    - 0.pool.ntp.org
-    - 1.pool.ntp.org
-    - 2.pool.ntp.org
-    - 3.pool.ntp.org  
+  - uri: "0.pool.ntp.org"
+    config: "minpoll 8"
+  - uri: "1.pool.ntp.org"
+    config: "minpoll 8"
+  - uri: "2.pool.ntp.org"
+    config: "minpoll 8"
+  - uri: "3.pool.ntp.org"
+    config: "minpoll 8"
 ```  
 
 ##### 3.4.2 | PATCH | Ensure /etc/hosts.allow is configured

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,12 +3,12 @@
 ubuntu1804cis_skip_for_travis: false
 
 ubuntu1804cis_notauto: false
-ubuntu1804cis_section1: true
+ubuntu1804cis_section1: false
 ubuntu1804cis_section2: true
-ubuntu1804cis_section3: true
-ubuntu1804cis_section4: true
-ubuntu1804cis_section5: true
-ubuntu1804cis_section6: true
+ubuntu1804cis_section3: false
+ubuntu1804cis_section4: false
+ubuntu1804cis_section5: false
+ubuntu1804cis_section6: false
 
 ubuntu1804cis_selinux_disable: false
 
@@ -329,10 +329,14 @@ ubuntu1804cis_time_synchronization: chrony
 # ubuntu1804cis_time_synchronization: ntp
 
 ubuntu1804cis_time_synchronization_servers:
-  - "0.pool.ntp.org"
-  - "1.pool.ntp.org"
-  - "2.pool.ntp.org"
-  - "3.pool.ntp.org"
+  - uri: "0.pool.ntp.org"
+    config: "minpoll 8"
+  - uri: "1.pool.ntp.org"
+    config: "minpoll 8"
+  - uri: "2.pool.ntp.org"
+    config: "minpoll 8"
+  - uri: "3.pool.ntp.org"
+    config: "minpoll 8"
 
 # 3.4.2 | PATCH | Ensure /etc/hosts.allow is configured
 ubuntu1804cis_host_allow:

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,12 +3,12 @@
 ubuntu1804cis_skip_for_travis: false
 
 ubuntu1804cis_notauto: false
-ubuntu1804cis_section1: false
+ubuntu1804cis_section1: true
 ubuntu1804cis_section2: true
-ubuntu1804cis_section3: false
-ubuntu1804cis_section4: false
-ubuntu1804cis_section5: false
-ubuntu1804cis_section6: false
+ubuntu1804cis_section3: true
+ubuntu1804cis_section4: true
+ubuntu1804cis_section5: true
+ubuntu1804cis_section6: true
 
 ubuntu1804cis_selinux_disable: false
 

--- a/templates/chrony.conf.j2
+++ b/templates/chrony.conf.j2
@@ -18,7 +18,7 @@
 # better to use IP numbers than host names.
 
 {% for server in ubuntu1804cis_time_synchronization_servers -%}
-server {{ server }} minpoll 8
+server {{ server.uri }} {{ server.config }}
 {% endfor %}
 
 # Look here for the admin password needed for chronyc.  The initial

--- a/templates/ntp.conf.j2
+++ b/templates/ntp.conf.j2
@@ -21,7 +21,7 @@ restrict ::1
 # Use public servers from the pool.ntp.org project.
 # Please consider joining the pool (http://www.pool.ntp.org/join.html).
 {% for server in ubuntu1804cis_time_synchronization_servers -%}
-server {{ server }} iburst
+server {{ server.uri }} {{ server.config }}
 {% endfor %}
 
 #broadcast 192.168.1.255 autokey        # broadcast server


### PR DESCRIPTION
This changes will allow the user to define the directives used when defining _ubuntu1804cis_time_synchronization_servers_.
With the current code, you can define the synchronization servers, but not the directives for each of them. 
The goal of these changes is to be able to use this role in different use cases.
In my case, I had to configure chrony in multiple AWS instances.
As you can see in [AWS documentation](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/set-time.html) the recommended configuration for this case is:
`server 169.254.169.123 prefer iburst`
But the current chrony.conf template only allowed me to use:
`server 169.254.169.123 minpoll 8`