### PR TITLE
fix(section1): aide setup

### DIFF
--- a/tasks/section1.yml
+++ b/tasks/section1.yml
@@ -529,7 +529,9 @@
 
 - name: "SCORED | 1.3.1 | PATCH | Ensure AIDE is installed"
   apt:
-      name: aide
+      name:
+        - aide
+        - aide-common
       state: present
       install_recommends: false
   when:

--- a/tasks/section1.yml
+++ b/tasks/section1.yml
@@ -543,17 +543,17 @@
       - patch
       - rule_1.3.1
 
-- name: "SCORED | 1.3.1 | PATCH | Ensure AIDE is installed"
-  command: /usr/bin/aide --init -B 'database_out=file:/var/lib/aide/aide.db.gz'
+- name: "SCORED | 1.3.1 | PATCH | Stat AIDE DB"
+  stat: path=/var/lib/aide/aide.db
+  register: aide_db
+- name: "SCORED | 1.3.1 | PATCH | Init AIDE | This may take a LONG time"
+  command: /usr/sbin/aideinit
   args:
-      creates: /var/lib/aide/aide.db.gz
-  changed_when: false
-  failed_when: false
-  async: 45
-  poll: 0
+      creates: /var/lib/aide/aide.db
   when:
       - ubuntu1804cis_config_aide
       - ubuntu1804cis_rule_1_3_1
+      - not aide_db.stat.exists
   tags:
       - level1
       - scored


### PR DESCRIPTION
This pull request adapts the playbook to changes introduced by Ubuntu 18.04:
* [x] add `aide-common` to packages, as it is required but not marked as required anymore 
* [x] switches the initialization from `aide --init` to special tool `aideinit`

Closes #10 