### PR TITLE
Don't loop over apt

### DIFF
--- a/molecule/default/playbook.yml
+++ b/molecule/default/playbook.yml
@@ -7,10 +7,9 @@
   pre_tasks:
     - name: install packages for testing under docker
       apt:
-        name: "{{ item }}"
+        name:
+          - openssh-server
         state: present
-      with_items:
-        - openssh-server
     - name: pretask2
       file:
         name: /boot/grub

--- a/tasks/section2.yml
+++ b/tasks/section2.yml
@@ -303,11 +303,10 @@
 
 - name: "SCORED | 2.2.2 | PATCH | Ensure X Window System is not installed"
   apt:
-      name: "{{ item }}"
+      name:
+        - "@X Window System"
+        - "x11*"
       state: absent
-  with_items:
-      - "@X Window System"
-      - "x11*"
   when:
       - ubuntu1804cis_xwindows_required == false
       - ubuntu1804cis_rule_2_2_2


### PR DESCRIPTION
Ansible is deprecating the special handling of loops on apt tasks in favor of lists of names. This PR updates this role to reflect that change.