### PR TITLE
Update benchmarks

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,15 @@ Example Playbook
     - Ubuntu1804-CIS
 ```
 
+To run the tasks in this repository, first create this file one level above the repository
+(i.e. the playbook .yml and the directory `Ubuntu1804-CIS` should be next to each other),
+then review the file `defaults/main.yml` and disable any rule/section you do not wish to execute.
+
+Assuming you named the file `site.yml`, run it with:
+```bash
+ansible-playbook site.yml
+```
+
 Tags
 ----
 Many tags are available for precise control of what is and is not changed.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -26,8 +26,6 @@ ubuntu1804cis_rule_1_1_1_3: true
 ubuntu1804cis_rule_1_1_1_4: true
 ubuntu1804cis_rule_1_1_1_5: true
 ubuntu1804cis_rule_1_1_1_6: true
-ubuntu1804cis_rule_1_1_1_7: true
-ubuntu1804cis_rule_1_1_1_8: true
 ubuntu1804cis_rule_1_1_2: true
 ubuntu1804cis_rule_1_1_3: true
 ubuntu1804cis_rule_1_1_4: true
@@ -48,12 +46,8 @@ ubuntu1804cis_rule_1_1_18: true
 ubuntu1804cis_rule_1_1_19: true
 ubuntu1804cis_rule_1_1_20: true
 ubuntu1804cis_rule_1_1_21: true
-ubuntu1804cis_rule_1_1_22: true
 ubuntu1804cis_rule_1_2_1: true
 ubuntu1804cis_rule_1_2_2: true
-ubuntu1804cis_rule_1_2_3: true
-ubuntu1804cis_rule_1_2_4: true
-ubuntu1804cis_rule_1_2_5: true
 ubuntu1804cis_rule_1_3_1: true
 ubuntu1804cis_rule_1_3_2: true
 ubuntu1804cis_rule_1_4_1: true
@@ -86,6 +80,10 @@ ubuntu1804cis_rule_2_1_4: true
 ubuntu1804cis_rule_2_1_5: true
 ubuntu1804cis_rule_2_1_6: true
 ubuntu1804cis_rule_2_1_7: true
+ubuntu1804cis_rule_2_1_8: true
+ubuntu1804cis_rule_2_1_9: true
+ubuntu1804cis_rule_2_1_10: true
+ubuntu1804cis_rule_2_1_11: true
 ubuntu1804cis_rule_2_2_1_1: true
 ubuntu1804cis_rule_2_2_1_2: true
 ubuntu1804cis_rule_2_2_1_3: true
@@ -105,10 +103,6 @@ ubuntu1804cis_rule_2_2_14: true
 ubuntu1804cis_rule_2_2_15: true
 ubuntu1804cis_rule_2_2_16: true
 ubuntu1804cis_rule_2_2_17: true
-ubuntu1804cis_rule_2_2_18: true
-ubuntu1804cis_rule_2_2_19: true
-ubuntu1804cis_rule_2_2_20: true
-ubuntu1804cis_rule_2_2_21: true
 ubuntu1804cis_rule_2_3_1: true
 ubuntu1804cis_rule_2_3_2: true
 ubuntu1804cis_rule_2_3_3: true
@@ -393,7 +387,7 @@ ubuntu1804cis_pwquality:
     value: '-1'
 
 ubuntu1804cis_pass:
-  max_days: 90
+  max_days: 365
   min_days: 7
   warn_age: 7
 

--- a/tasks/prelim.yml
+++ b/tasks/prelim.yml
@@ -79,6 +79,8 @@
 - name: "PRELIM | Check for rsyslog service"
   shell: "systemctl is-enabled rsyslog; true"
   register: rsyslog_service_status
+  changed_when: false
+  check_mode: false
 
 - name: "PRELIM | Check for ntpd service"
   shell: "set -o pipefail

--- a/tasks/prelim.yml
+++ b/tasks/prelim.yml
@@ -70,6 +70,16 @@
   changed_when: false
   check_mode: false
 
+- name: "PRELIM | Check for openbsd-inetd service"
+  shell: "dpkg -s openbsd-inetd | grep -o 'ok installed'; true"
+  register: openbsd_inetd_service_status
+  changed_when: false
+  check_mode: false
+
+- name: "PRELIM | Check for rsyslog service"
+  shell: "systemctl is-enabled rsyslog; true"
+  register: rsyslog_service_status
+
 - name: "PRELIM | Check for ntpd service"
   shell: "set -o pipefail
       systemctl show {{ ntp_service[ansible_os_family] }} | grep LoadState | cut -d = -f 2"
@@ -299,3 +309,21 @@
   stat:
     path: /boot/grub/grub.cfg
   register: grub_cfg
+
+- name: "PRELIM | Check that system accounts are non-login #1"
+  shell: >
+    egrep -v "^\+" /etc/passwd | awk -F: '($1!="root" && $1!="sync" &&
+    $1!="shutdown" && $1!="halt" && $3<1000 && $7!="/usr/sbin/nologin" &&
+    $7!="/bin/false") {print}'
+  register: system_accounts_non_login_1
+  changed_when: false
+  check_mode: false
+
+
+- name: "PRELIM | Check that system accounts are non-login #2"
+  shell: >
+    for user in `awk -F: '($1!="root" && $3 < 1000) {print $1 }' /etc/passwd`; do
+    passwd -S $user | awk -F ' ' '($2!="L") {print $1}'; done
+  register: system_accounts_non_login_2
+  changed_when: false
+  check_mode: false

--- a/tasks/section1.yml
+++ b/tasks/section1.yml
@@ -157,38 +157,7 @@
       - filesystems
       - rule_1.1.1.5
 
-- name: "SCORED | 1.1.1.6 | PATCH | Ensure mounting of squashfs filesystems is disabled"
-  lineinfile:
-      dest: /etc/modprobe.d/CIS.conf
-      regexp: "^(#)?install squashfs(\\s|$)"
-      line: "install squashfs /bin/true"
-      state: present
-      create: true
-  when:
-      - ubuntu1804cis_rule_1_1_1_6
-  tags:
-      - level1
-      - scored
-      - patch
-      - squashfs
-      - filesystems
-      - rule_1.1.1.6
-
-- name: "SCORED | 1.1.1.6 | PATCH | Remove squashfs module"
-  modprobe:
-      name: squashfs
-      state: absent
-  when:
-      - ubuntu1804cis_rule_1_1_1_6
-  tags:
-      - level1
-      - scored
-      - patch
-      - squashfs
-      - filesystems
-      - rule_1.1.1.6
-
-- name: "SCORED | 1.1.1.7 | PATCH | Ensure mounting of udf filesystems is disabled"
+- name: "SCORED | 1.1.1.6 | PATCH | Ensure mounting of udf filesystems is disabled"
   lineinfile:
       dest: /etc/modprobe.d/CIS.conf
       regexp: "^(#)?install udf(\\s|$)"
@@ -196,59 +165,28 @@
       state: present
       create: true
   when:
-      - ubuntu1804cis_rule_1_1_1_7
+      - ubuntu1804cis_rule_1_1_1_6
   tags:
       - level1
       - scored
       - patch
       - udf
       - filesystems
-      - rule_1.1.1.7
+      - rule_1.1.1.6
 
-- name: "SCORED | 1.1.1.7 | PATCH | Remove udf module"
+- name: "SCORED | 1.1.1.6 | PATCH | Remove udf module"
   modprobe:
       name: udf
       state: absent
   when:
-      - ubuntu1804cis_rule_1_1_1_7
+      - ubuntu1804cis_rule_1_1_1_6
   tags:
       - level1
       - scored
       - patch
       - udf
       - filesystems
-      - rule_1.1.1.7
-
-- name: "SCORED | 1.1.1.8 | PATCH | Ensure mounting of FAT filesystems is disabled"
-  lineinfile:
-      dest: /etc/modprobe.d/CIS.conf
-      regexp: "^(#)?install vfat(\\s|$)"
-      line: "install vfat /bin/true"
-      state: present
-      create: true
-  when:
-      - ubuntu1804cis_rule_1_1_1_8
-  tags:
-      - level1
-      - scored
-      - patch
-      - vfat
-      - filesystems
-      - rule_1.1.1.8
-
-- name: "SCORED | 1.1.1.8 | PATCH | Remove FAT module"
-  modprobe:
-      name: vfat
-      state: absent
-  when:
-      - ubuntu1804cis_rule_1_1_1_8
-  tags:
-      - level2
-      - scored
-      - patch
-      - vfat
-      - filesystems
-      - rule_1.1.1.8
+      - rule_1.1.1.6
 
 - name: "SCORED | 1.1.2 | PATCH | Ensure separate partition exists for /tmp | enable and start/restart tmp.mount"
   copy:
@@ -520,16 +458,16 @@
       - rule_1.2.1
 
 
-- name: "NOTSCORED | 1.2.3 | PATCH | Ensure GPG keys are configured"
+- name: "NOTSCORED | 1.2.2 | PATCH | Ensure GPG keys are configured"
   command: /bin/true
   changed_when: false
   when:
-      - ubuntu1804cis_rule_1_2_3
+      - ubuntu1804cis_rule_1_2_2
   tags:
       - level1
       - notscored
       - patch
-      - rule_1.2.3
+      - rule_1.2.2
       - notimplemented
 
 - name: "SCORED | 1.3.1 | PATCH | Ensure AIDE is installed (install nullmailer instead of postfix)"

--- a/tasks/section2.yml
+++ b/tasks/section2.yml
@@ -180,45 +180,37 @@
       - rule_2.1.5
       - skip_ansible_lint
 
-- name: "SCORED | 2.1.6 | PATCH | Ensure rsh server is not enabled | rsh"
-  service:
-    name: rsh.socket
-    state: stopped
-    enabled: false
-  when:
-    - ubuntu1804cis_rsh_server == false
-    - rsh_service_status.stdout == "loaded"
-    - ubuntu1804cis_rule_2_1_6
-  tags:
-    - level1
-    - scored
-    - patch
-    - rule_2.1.6
+- name: "SCORED | 2.1.6 | PATCH | Ensure rsh server is not enabled | rsh, rlogin, rexec"
+  block:
+      - name: "SCORED | 2.1.6 | PATCH | Ensure rsh server is not enabled | rsh"
+        service:
+          name: rsh.socket
+          state: stopped
+          enabled: false
+        when:
+          - ubuntu1804cis_rsh_server == false
+          - rsh_service_status.stdout == "loaded"
+          - ubuntu1804cis_rule_2_1_6
 
-- name: "SCORED | 2.1.6 | PATCH | Ensure rsh server is not enabled | rlogin"
-  service:
-    name: rlogin.socket
-    state: stopped
-    enabled: false
-  when:
-    - ubuntu1804cis_rsh_server == false
-    - rlogin_service_status.stdout == "loaded"
-    - ubuntu1804cis_rule_2_1_6
-  tags:
-    - level1
-    - scored
-    - patch
-    - rule_2.1.6
+      - name: "SCORED | 2.1.6 | PATCH | Ensure rsh server is not enabled | rlogin"
+        service:
+          name: rlogin.socket
+          state: stopped
+          enabled: false
+        when:
+          - ubuntu1804cis_rsh_server == false
+          - rlogin_service_status.stdout == "loaded"
+          - ubuntu1804cis_rule_2_1_6
 
-- name: "SCORED | 2.1.6 | PATCH | Ensure rsh server is not enabled | rexec"
-  service:
-    name: rexec.socket
-    state: stopped
-    enabled: false
-  when:
-    - ubuntu1804cis_rsh_server == false
-    - rexec_service_status.stdout == "loaded"
-    - ubuntu1804cis_rule_2_1_6
+      - name: "SCORED | 2.1.6 | PATCH | Ensure rsh server is not enabled | rexec"
+        service:
+          name: rexec.socket
+          state: stopped
+          enabled: false
+        when:
+          - ubuntu1804cis_rsh_server == false
+          - rexec_service_status.stdout == "loaded"
+          - ubuntu1804cis_rule_2_1_6
   tags:
     - level1
     - scored

--- a/tasks/section2.yml
+++ b/tasks/section2.yml
@@ -257,6 +257,7 @@
       - name: "SCORED | 2.1.9 | PATCH | Ensure tftp server is not enabled"
         service:
             name: tftp
+            state: stopped
             enabled: no
         notify: restart xinetd
         when:
@@ -643,7 +644,22 @@
       - patch
       - rule_2.2.15
 
-- name: "SCORED | 2.2.16 | PATCH | Ensure NIS Server is not enabled"
+- name: "SCORED | 2.2.16 | PATCH | Ensure rsync service is not enabled "
+  service:
+    name: rsyncd
+    state: stopped
+    enabled: false
+  when:
+    - not ubuntu1804cis_rsyncd_server
+    - rsyncd_service_status.stdout == "loaded"
+    - ubuntu1804cis_rule_2_2_16
+  tags:
+    - level1
+    - scored
+    - patch
+    - rule_2.2.16
+
+- name: "SCORED | 2.2.17 | PATCH | Ensure NIS Server is not enabled"
   service:
       name: ypserv
       state: stopped
@@ -651,120 +667,12 @@
   when:
       - not ubuntu1804cis_nis_server
       - ypserv_service_status.stdout == "loaded"
-      - ubuntu1804cis_rule_2_2_16
-  tags:
-      - level1
-      - scored
-      - patch
-      - rule_2.2.16
-
-- name: "SCORED | 2.2.17 | PATCH | Ensure rsh server is not enabled | rsh"
-  service:
-      name: rsh.socket
-      state: stopped
-      enabled: false
-  when:
-      - not ubuntu1804cis_rsh_server
-      - rsh_service_status.stdout == "loaded"
       - ubuntu1804cis_rule_2_2_17
   tags:
       - level1
       - scored
       - patch
       - rule_2.2.17
-
-- name: "SCORED | 2.2.17 | PATCH | Ensure rsh server is not enabled | rlogin"
-  service:
-      name: rlogin.socket
-      state: stopped
-      enabled: false
-  when:
-      - not ubuntu1804cis_rsh_server
-      - rlogin_service_status.stdout == "loaded"
-      - ubuntu1804cis_rule_2_2_17
-  tags:
-      - level1
-      - scored
-      - patch
-      - rule_2.2.17
-
-- name: "SCORED | 2.2.17 | PATCH | Ensure rsh server is not enabled | rexec"
-  service:
-      name: rexec.socket
-      state: stopped
-      enabled: false
-  when:
-      - not ubuntu1804cis_rsh_server
-      - rexec_service_status.stdout == "loaded"
-      - ubuntu1804cis_rule_2_2_17
-  tags:
-      - level1
-      - scored
-      - patch
-      - rule_2.2.17
-
-- name: "SCORED | 2.2.18 | PATCH | Ensure telnet server is not enabled"
-  service:
-      name: telnet
-      state: stopped
-      enabled: false
-  when:
-      - not ubuntu1804cis_telnet_server
-      - telnet_service_status.stdout == "loaded"
-      - ubuntu1804cis_rule_2_2_18
-  tags:
-      - level1
-      - scored
-      - patch
-      - rule_2.2.18
-
-- name: "SCORED | 2.2.19 | PATCH | Ensure tftp server is not enabled"
-  service:
-      name: tftp
-      state: stopped
-      enabled: false
-  when:
-      - not ubuntu1804cis_tftp_server
-      - tftp_service_status.stdout == "loaded"
-      - ubuntu1804cis_rule_2_2_19
-  tags:
-      - level1
-      - scored
-      - scored
-      - insecure_services
-      - tftp
-      - patch
-      - rule_2.2.19
-
-- name: "SCORED | 2.2.20 | PATCH | Ensure rsync service is not enabled "
-  service:
-      name: rsyncd
-      state: stopped
-      enabled: false
-  when:
-      - not ubuntu1804cis_rsyncd_server
-      - rsyncd_service_status.stdout == "loaded"
-      - ubuntu1804cis_rule_2_2_20
-  tags:
-      - level1
-      - scored
-      - patch
-      - rule_2.2.20
-
-- name: "SCORED | 2.2.21 | PATCH | Ensure talk server is not enabled"
-  service:
-      name: ntalk
-      state: stopped
-      enabled: false
-  when:
-      - not ubuntu1804cis_ntalk_server
-      - ntalk_service_status.stdout == "loaded"
-      - ubuntu1804cis_rule_2_2_21
-  tags:
-      - level1
-      - scored
-      - patch
-      - rule_2.2.21
 
 - name: "SCORED | 2.3.1 | PATCH | Ensure NIS Client is not installed"
   apt:

--- a/tasks/section2.yml
+++ b/tasks/section2.yml
@@ -180,14 +180,89 @@
       - rule_2.1.5
       - skip_ansible_lint
 
-- name: "SCORED | 2.1.6 | PATCH | Ensure tftp server is not enabled"
+- name: "SCORED | 2.1.6 | PATCH | Ensure rsh server is not enabled | rsh"
+  service:
+    name: rsh.socket
+    state: stopped
+    enabled: false
+  when:
+    - ubuntu1804cis_rsh_server == false
+    - rsh_service_status.stdout == "loaded"
+    - ubuntu1804cis_rule_2_1_6
+  tags:
+    - level1
+    - scored
+    - patch
+    - rule_2.1.6
+
+- name: "SCORED | 2.1.6 | PATCH | Ensure rsh server is not enabled | rlogin"
+  service:
+    name: rlogin.socket
+    state: stopped
+    enabled: false
+  when:
+    - ubuntu1804cis_rsh_server == false
+    - rlogin_service_status.stdout == "loaded"
+    - ubuntu1804cis_rule_2_1_6
+  tags:
+    - level1
+    - scored
+    - patch
+    - rule_2.1.6
+
+- name: "SCORED | 2.1.6 | PATCH | Ensure rsh server is not enabled | rexec"
+  service:
+    name: rexec.socket
+    state: stopped
+    enabled: false
+  when:
+    - ubuntu1804cis_rsh_server == false
+    - rexec_service_status.stdout == "loaded"
+    - ubuntu1804cis_rule_2_1_6
+  tags:
+    - level1
+    - scored
+    - patch
+    - rule_2.1.6
+
+- name: "SCORED | 2.1.7 | PATCH | Ensure talk server is not enabled"
+  service:
+    name: ntalk
+    state: stopped
+    enabled: false
+  when:
+    - ubuntu1804cis_ntalk_server == false
+    - ntalk_service_status.stdout == "loaded"
+    - ubuntu1804cis_rule_2_1_7
+  tags:
+    - level1
+    - scored
+    - patch
+    - rule_2.1.7
+
+- name: "SCORED | 2.1.8 | PATCH | Ensure telnet server is not enabled"
+  service:
+    name: telnet
+    state: stopped
+    enabled: false
+  when:
+    - ubuntu1804cis_telnet_server == false
+    - telnet_service_status.stdout == "loaded"
+    - ubuntu1804cis_rule_2_1_8
+  tags:
+    - level1
+    - scored
+    - patch
+    - rule_2.1.8
+
+- name: "SCORED | 2.1.9 | PATCH | Ensure tftp server is not enabled"
   block:
-      - name: "SCORED | 2.1.6 | PATCH | Ensure tftp server is not enabled"
+      - name: "SCORED | 2.1.9 | PATCH | Ensure tftp server is not enabled"
         stat:
             path: /etc/xinetd.d/tftp
         register: tftp_service
 
-      - name: "SCORED | 2.1.6 | PATCH | Ensure tftp server is not enabled"
+      - name: "SCORED | 2.1.9 | PATCH | Ensure tftp server is not enabled"
         service:
             name: tftp
             enabled: no
@@ -198,14 +273,14 @@
         tags:
             - skip_ansible_lint
   when:
-      - ubuntu1804cis_rule_2_1_6
+      - ubuntu1804cis_rule_2_1_9
   tags:
       - level1
       - scored
       - patch
-      - rule_2.1.6
+      - rule_2.1.9
 
-- name: "SCORED | 2.1.7 | PATCH | Ensure xinetd is not enabled"
+- name: "SCORED | 2.1.10 | PATCH | Ensure xinetd is not enabled"
   service:
       name: xinetd
       state: stopped
@@ -213,12 +288,25 @@
   when:
       - xinetd_service_status.stdout == "loaded"
       - not ubuntu1804cis_xinetd_required
-      - ubuntu1804cis_rule_2_1_7
+      - ubuntu1804cis_rule_2_1_10
   tags:
       - level1
       - patch
       - scored
-      - rule_2.1.7
+      - rule_2.1.10
+
+- name: "SCORED | 2.1.11 | PATCH | Ensure openbsd-inetd is not installed"
+  apt:
+    name: openbsd-inetd
+    state: absent
+  when:
+    - openbsd_inetd_service_status.stdout == "ok installed"
+    - ubuntu1804cis_rule_2_1_11
+  tags:
+    - level1
+    - patch
+    - scored
+    - rule_2.1.11
 
 - name: "NOTSCORED | 2.2.1.1 | PATCH | Ensure time synchronization is in use"
   block:

--- a/tasks/section3.yml
+++ b/tasks/section3.yml
@@ -287,7 +287,7 @@
       - patch
       - rule_3.4.4
 
-- name: "SCORED | 3.4.5 | PATCH | Ensure permissions on /etc/hosts.deny are 644"
+- name: "SCORED | 3.4.5 | PATCH | Ensure permissions on /etc/hosts.deny are configured"
   file:
       dest: /etc/hosts.deny
       owner: root

--- a/tasks/section4.yml
+++ b/tasks/section4.yml
@@ -400,6 +400,7 @@
   when:
       - ubuntu1804cis_rule_4_2_1_1
       - rsyslog_service_status.stdout != "enabled"
+      - not ubuntu1804cis_skip_for_travis
   tags:
       - level1
       - scored

--- a/tasks/section4.yml
+++ b/tasks/section4.yml
@@ -374,7 +374,6 @@
       - patch
       - auditd
       - rule_4.1.17
-      - notimplemented
 
 - name: "SCORED | 4.1.18 | PATCH | Ensure the audit configuration is immutable"
   template:
@@ -395,32 +394,18 @@
       - auditd
       - rule_4.1.18
 
-- name: "SCORED | 4.2.3 | PATCH | Ensure rsyslog or syslog-ng is installed"
-  apt:
-      name: "{{ ubuntu1804cis_syslog }}"
-      state: present
-      install_recommends: false
-  when:
-      - ubuntu1804cis_rule_4_2_3
-  tags:
-      - level1
-      - scored
-      - patch
-      - syslog
-      - rule_4.2.3
-
 - name: "SCORED | 4.2.1.1 | PATCH | Ensure rsyslog Service is enabled"
-  command: /bin/true
+  command: "systemctl enable rsyslog"
   changed_when: false
   when:
       - ubuntu1804cis_rule_4_2_1_1
+      - rsyslog_service_status.stdout != "enabled"
   tags:
       - level1
       - scored
       - patch
       - syslog
       - rule_4.2.1.1
-      - notimplemented
 
 - name: "NOTSCORED | 4.2.1.2 | PATCH | Ensure logging is configured"
   command: /bin/true
@@ -552,6 +537,20 @@
       - syslog
       - rule_4.2.2.5
       - notimplemented
+
+- name: "SCORED | 4.2.3 | PATCH | Ensure rsyslog or syslog-ng is installed"
+  apt:
+    name: "{{ ubuntu1804cis_syslog }}"
+    state: present
+    install_recommends: false
+  when:
+    - ubuntu1804cis_rule_4_2_3
+  tags:
+    - level1
+    - scored
+    - patch
+    - syslog
+    - rule_4.2.3
 
 - name: "SCORED | 4.2.4 | PATCH | Ensure permissions on all logfiles are configured"
   command: find /var/log -type f -exec chmod g-wx,o-rwx {} +

--- a/tasks/section4.yml
+++ b/tasks/section4.yml
@@ -397,17 +397,17 @@
 #4.2.4 is here due to dependencies to 4.2.1.x
 - name: "SCORED | 4.2.3 | PATCH | Ensure rsyslog or syslog-ng is installed"
   apt:
-    name: "{{ ubuntu1804cis_syslog }}"
-    state: present
-    install_recommends: false
+      name: "{{ ubuntu1804cis_syslog }}"
+      state: present
+      install_recommends: false
   when:
-    - ubuntu1804cis_rule_4_2_3
+      - ubuntu1804cis_rule_4_2_3
   tags:
-    - level1
-    - scored
-    - patch
-    - syslog
-    - rule_4.2.3
+      - level1
+      - scored
+      - patch
+      - syslog
+      - rule_4.2.3
 
 - name: "SCORED | 4.2.1.1 | PATCH | Ensure rsyslog Service is enabled"
   command: "systemctl enable rsyslog"

--- a/tasks/section4.yml
+++ b/tasks/section4.yml
@@ -394,13 +394,27 @@
       - auditd
       - rule_4.1.18
 
+#4.2.4 is here due to dependencies to 4.2.1.x
+- name: "SCORED | 4.2.3 | PATCH | Ensure rsyslog or syslog-ng is installed"
+  apt:
+    name: "{{ ubuntu1804cis_syslog }}"
+    state: present
+    install_recommends: false
+  when:
+    - ubuntu1804cis_rule_4_2_3
+  tags:
+    - level1
+    - scored
+    - patch
+    - syslog
+    - rule_4.2.3
+
 - name: "SCORED | 4.2.1.1 | PATCH | Ensure rsyslog Service is enabled"
   command: "systemctl enable rsyslog"
   changed_when: false
   when:
       - ubuntu1804cis_rule_4_2_1_1
       - rsyslog_service_status.stdout != "enabled"
-      - not ubuntu1804cis_skip_for_travis
   tags:
       - level1
       - scored
@@ -538,20 +552,6 @@
       - syslog
       - rule_4.2.2.5
       - notimplemented
-
-- name: "SCORED | 4.2.3 | PATCH | Ensure rsyslog or syslog-ng is installed"
-  apt:
-    name: "{{ ubuntu1804cis_syslog }}"
-    state: present
-    install_recommends: false
-  when:
-    - ubuntu1804cis_rule_4_2_3
-  tags:
-    - level1
-    - scored
-    - patch
-    - syslog
-    - rule_4.2.3
 
 - name: "SCORED | 4.2.4 | PATCH | Ensure permissions on all logfiles are configured"
   command: find /var/log -type f -exec chmod g-wx,o-rwx {} +

--- a/tasks/section5.yml
+++ b/tasks/section5.yml
@@ -487,7 +487,7 @@
       - patch
       - rule_5.3.4
 
-- name: "SCORED | 5.4.1.1 | PATCH | Ensure password expiration is 90 days or less"
+- name: "SCORED | 5.4.1.1 | PATCH | Ensure password expiration is 365 days or less"
   lineinfile:
       state: present
       dest: /etc/login.defs
@@ -542,15 +542,25 @@
       - notimplemented
 
 - name: "SCORED | 5.4.2 | PATCH | Ensure system accounts are non-login"
-  command: /bin/true
+  command: >
+    for user in `awk -F: '($3 < 1000) {print $1 }' /etc/passwd`; do
+     if [ $user != "root" ]; then
+      usermod -L $user
+      if [ $user != "sync" ] && [ $user != "shutdown" ] && [ $user != "halt" ];
+      then
+        usermod -s /usr/sbin/nologin $user
+      fi
+     fi
+    done
   changed_when: false
   when:
       - ubuntu1804cis_rule_5_4_2
+      - system_accounts_non_login_1.stdout != ''
+      - system_accounts_non_login_2.stdout != ''
   tags:
       - level1
       - patch
       - rule_5.4.2
-      - notimplemented
       - scored
 
 - name: "SCORED | 5.4.3 | PATCH | Ensure default group for the root account is GID 0"


### PR DESCRIPTION
- Removed: 1.1.1.6 | mounting of squashfs tasks (no more part of the CIS benchmark)

- Removed: 1.1.1.8 | mounting of FAT filesystems tasks (no more part of the CIS benchmark)

- Update: 2.1.x | tasks rearranged to meet the CIS specifications

- NEW: 2.1.11 | PATCH | Ensure openbsd-inetd is not installed

- Updated: 4.2.1.1 | PATCH | Ensure rsyslog Service is enabled

- Updated: 5.4.1.1 | PATCH | Ensure password expiration is 365 days or less - Changed default password expiration from 90 to 365

- NEW: 5.4.2 | PATCH | Ensure system accounts are non-login