### PR TITLE
Fixing boolean bare variable deprecation warning

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -24,32 +24,32 @@
 
 - include: section1.yml
   become: true
-  when: ubuntu1804cis_section1
+  when: ubuntu1804cis_section1|bool
   tags: section1
 
 - include: section2.yml
   become: true
-  when: ubuntu1804cis_section2
+  when: ubuntu1804cis_section2|bool
   tags: section2
 
 - include: section3.yml
   become: true
-  when: ubuntu1804cis_section3
+  when: ubuntu1804cis_section3|bool
   tags: section3
 
 - include: section4.yml
   become: true
-  when: ubuntu1804cis_section4
+  when: ubuntu1804cis_section4|bool
   tags: section4
 
 - include: section5.yml
   become: true
-  when: ubuntu1804cis_section5
+  when: ubuntu1804cis_section5|bool
   tags: section5
 
 - include: section6.yml
   become: true
-  when: ubuntu1804cis_section6
+  when: ubuntu1804cis_section6|bool
   tags: section6
 
 - include: post.yml

--- a/tasks/section1.yml
+++ b/tasks/section1.yml
@@ -10,7 +10,7 @@
       mode: 0644
       create: true
   when:
-      - ubuntu1804cis_rule_1_1_1_1
+      - ubuntu1804cis_rule_1_1_1_1|bool
   tags:
       - level1
       - scored
@@ -24,7 +24,7 @@
       name: cramfs
       state: absent
   when:
-      - ubuntu1804cis_rule_1_1_1_1
+      - ubuntu1804cis_rule_1_1_1_1|bool
       - not ubuntu1804cis_skip_for_travis
   tags:
       - level1
@@ -42,7 +42,7 @@
       state: present
       create: true
   when:
-      - ubuntu1804cis_rule_1_1_1_2
+      - ubuntu1804cis_rule_1_1_1_2|bool
   tags:
       - level1
       - scored
@@ -56,7 +56,7 @@
       name: freevxfs
       state: absent
   when:
-      - ubuntu1804cis_rule_1_1_1_2
+      - ubuntu1804cis_rule_1_1_1_2|bool
       - not ubuntu1804cis_skip_for_travis
   tags:
       - level1
@@ -74,7 +74,7 @@
       state: present
       create: true
   when:
-      - ubuntu1804cis_rule_1_1_1_3
+      - ubuntu1804cis_rule_1_1_1_3|bool
   tags:
       - level1
       - scored
@@ -88,7 +88,7 @@
       name: jffs2
       state: absent
   when:
-      - ubuntu1804cis_rule_1_1_1_3
+      - ubuntu1804cis_rule_1_1_1_3|bool
       - not ubuntu1804cis_skip_for_travis
   tags:
       - level1
@@ -106,7 +106,7 @@
       state: present
       create: true
   when:
-      - ubuntu1804cis_rule_1_1_1_4
+      - ubuntu1804cis_rule_1_1_1_4|bool
   tags:
       - level1
       - scored
@@ -120,7 +120,7 @@
       name: hfs
       state: absent
   when:
-      - ubuntu1804cis_rule_1_1_1_4
+      - ubuntu1804cis_rule_1_1_1_4|bool
       - not ubuntu1804cis_skip_for_travis
   tags:
       - level1
@@ -138,7 +138,7 @@
       state: present
       create: true
   when:
-      - ubuntu1804cis_rule_1_1_1_5
+      - ubuntu1804cis_rule_1_1_1_5|bool
   tags:
       - level1
       - scored
@@ -152,7 +152,7 @@
       name: hfsplus
       state: absent
   when:
-      - ubuntu1804cis_rule_1_1_1_5
+      - ubuntu1804cis_rule_1_1_1_5|bool
       - not ubuntu1804cis_skip_for_travis
   tags:
       - level1
@@ -170,7 +170,7 @@
       state: present
       create: true
   when:
-      - ubuntu1804cis_rule_1_1_1_6
+      - ubuntu1804cis_rule_1_1_1_6|bool
   tags:
       - level1
       - scored
@@ -184,7 +184,7 @@
       name: udf
       state: absent
   when:
-      - ubuntu1804cis_rule_1_1_1_6
+      - ubuntu1804cis_rule_1_1_1_6|bool
       - not ubuntu1804cis_skip_for_travis
   tags:
       - level1
@@ -206,7 +206,7 @@
   notify:
       - systemd restart tmp.mount
   when:
-      - ubuntu1804cis_rule_1_1_2
+      - ubuntu1804cis_rule_1_1_2|bool
       - not ubuntu1804cis_skip_for_travis
   tags:
       - level2
@@ -222,7 +222,7 @@
       masked: no
       state: started
   when:
-      - ubuntu1804cis_rule_1_1_2
+      - ubuntu1804cis_rule_1_1_2|bool
       - not ubuntu1804cis_skip_for_travis
   tags:
       - level2
@@ -245,8 +245,8 @@
   notify:
       - systemd restart tmp.mount
   when:
-      - ubuntu1804cis_rule_1_1_3
-      - ubuntu1804cis_rule_1_1_4
+      - ubuntu1804cis_rule_1_1_3|bool
+      - ubuntu1804cis_rule_1_1_4|bool
   tags:
       - level1
       - scored
@@ -260,7 +260,7 @@
   changed_when: false
   failed_when: false
   when:
-      - ubuntu1804cis_rule_1_1_5
+      - ubuntu1804cis_rule_1_1_5|bool
   tags:
       - level2
       - scored
@@ -274,7 +274,7 @@
   changed_when: false
   failed_when: false
   when:
-      - ubuntu1804cis_rule_1_1_6
+      - ubuntu1804cis_rule_1_1_6|bool
   tags:
       - level2
       - scored
@@ -293,9 +293,9 @@
       opts: "{{ ubuntu1804cis_vartmp['opts'] }}"
   when:
       - ubuntu1804cis_vartmp['enabled'] == 'yes'
-      - ubuntu1804cis_rule_1_1_7
-      - ubuntu1804cis_rule_1_1_8
-      - ubuntu1804cis_rule_1_1_9
+      - ubuntu1804cis_rule_1_1_7|bool
+      - ubuntu1804cis_rule_1_1_8|bool
+      - ubuntu1804cis_rule_1_1_9|bool
   tags:
       - level1
       - scored
@@ -310,7 +310,7 @@
   changed_when: false
   failed_when: false
   when:
-      - ubuntu1804cis_rule_1_1_10
+      - ubuntu1804cis_rule_1_1_10|bool
   tags:
       - level2
       - scored
@@ -324,7 +324,7 @@
   changed_when: false
   failed_when: false
   when:
-      - ubuntu1804cis_rule_1_1_11
+      - ubuntu1804cis_rule_1_1_11|bool
   tags:
       - level2
       - scored
@@ -338,7 +338,7 @@
   changed_when: false
   failed_when: false
   when:
-      - ubuntu1804cis_rule_1_1_12
+      - ubuntu1804cis_rule_1_1_12|bool
   tags:
       - level2
       - scored
@@ -354,7 +354,7 @@
       fstype: "{{ item.fstype }}"
       opts: "nodev"
   when:
-      - ubuntu1804cis_rule_1_1_13
+      - ubuntu1804cis_rule_1_1_13|bool
       - item.mount == "/home"
   with_items:
       - "{{ ansible_mounts }}"
@@ -374,9 +374,9 @@
       fstype: tmpfs
       opts: "defaults,nodev,nosuid,noexec"
   when:
-      - ubuntu1804cis_rule_1_1_14
-      - ubuntu1804cis_rule_1_1_15
-      - ubuntu1804cis_rule_1_1_16
+      - ubuntu1804cis_rule_1_1_14|bool
+      - ubuntu1804cis_rule_1_1_15|bool
+      - ubuntu1804cis_rule_1_1_16|bool
   tags:
       - level1
       - scored
@@ -389,7 +389,7 @@
   command: /bin/true
   changed_when: false
   when:
-      - ubuntu1804cis_rule_1_1_17
+      - ubuntu1804cis_rule_1_1_17|bool
   tags:
       - level1
       - notscored
@@ -401,7 +401,7 @@
   command: /bin/true
   changed_when: false
   when:
-      - ubuntu1804cis_rule_1_1_18
+      - ubuntu1804cis_rule_1_1_18|bool
   tags:
       - level1
       - notscored
@@ -413,7 +413,7 @@
   command: /bin/true
   changed_when: false
   when:
-      - ubuntu1804cis_rule_1_1_19
+      - ubuntu1804cis_rule_1_1_19|bool
   tags:
       - level1
       - notscored
@@ -430,7 +430,7 @@
   changed_when: false
   failed_when: false
   when:
-      - ubuntu1804cis_rule_1_1_20
+      - ubuntu1804cis_rule_1_1_20|bool
       # - sticky_bit_on_worldwritable_dirs_audit.rc == '0'
   tags:
       - level1
@@ -445,7 +445,7 @@
   when:
       - not ubuntu1804cis_allow_autofs
       - autofs_service_status.stdout == "loaded"
-      - ubuntu1804cis_rule_1_1_21
+      - ubuntu1804cis_rule_1_1_21|bool
   tags:
       - level1
       - scored
@@ -456,7 +456,7 @@
   command: /bin/true
   changed_when: false
   when:
-      - ubuntu1804cis_rule_1_2_1
+      - ubuntu1804cis_rule_1_2_1|bool
   tags:
       - level1
       - notscored
@@ -468,7 +468,7 @@
   command: /bin/true
   changed_when: false
   when:
-      - ubuntu1804cis_rule_1_2_2
+      - ubuntu1804cis_rule_1_2_2|bool
   tags:
       - level1
       - notscored
@@ -483,7 +483,7 @@
       state: present
       install_recommends: false
   when:
-      - ubuntu1804cis_rule_1_3_1
+      - ubuntu1804cis_rule_1_3_1|bool
       - not postfix_installed.rc == 0
   tags:
       - level1
@@ -500,7 +500,7 @@
       state: present
       install_recommends: false
   when:
-      - ubuntu1804cis_rule_1_3_1
+      - ubuntu1804cis_rule_1_3_1|bool
   tags:
       - level1
       - scored
@@ -517,8 +517,8 @@
   args:
       creates: /var/lib/aide/aide.db
   when:
-      - ubuntu1804cis_config_aide
-      - ubuntu1804cis_rule_1_3_1
+      - ubuntu1804cis_config_aide|bool
+      - ubuntu1804cis_rule_1_3_1|bool
       - not aide_db.stat.exists
       - not ubuntu1804cis_skip_for_travis
   tags:
@@ -540,7 +540,7 @@
       weekday: "{{ ubuntu1804cis_aide_cron['aide_weekday'] | default('*') }}"
       job: "{{ ubuntu1804cis_aide_cron['aide_job'] }}"
   when:
-      - ubuntu1804cis_rule_1_3_2
+      - ubuntu1804cis_rule_1_3_2|bool
   tags:
       - level1
       - scored
@@ -557,7 +557,7 @@
       mode: 0600
   when:
       - ansible_os_family == "Debian"
-      - ubuntu1804cis_rule_1_4_1
+      - ubuntu1804cis_rule_1_4_1|bool
   tags:
       - level1
       - scored
@@ -570,8 +570,8 @@
       password: "{{ ubuntu1804cis_bootloader_password }}"
   register: grub_pass
   when:
-      - ubuntu1804cis_set_boot_pass
-      - ubuntu1804cis_rule_1_4_2
+      - ubuntu1804cis_set_boot_pass|bool
+      - ubuntu1804cis_rule_1_4_2|bool
   tags:
       - level1
       - scored
@@ -584,7 +584,7 @@
   command: /bin/true
   changed_when: false
   when:
-      - ubuntu1804cis_rule_1_4_3
+      - ubuntu1804cis_rule_1_4_3|bool
   tags:
       - level1
       - notscored
@@ -600,7 +600,7 @@
       line: '*                hard    core            0'
       insertbefore: '^# End of file'
   when:
-      - ubuntu1804cis_rule_1_5_1
+      - ubuntu1804cis_rule_1_5_1|bool
   tags:
       - level1
       - scored
@@ -617,7 +617,7 @@
       sysctl_set: true
       ignoreerrors: true
   when:
-      - ubuntu1804cis_rule_1_5_1
+      - ubuntu1804cis_rule_1_5_1|bool
   tags:
       - level1
       - scored
@@ -633,7 +633,7 @@
       executable: /bin/bash
   changed_when: false
   when:
-      - ubuntu1804cis_rule_1_5_2
+      - ubuntu1804cis_rule_1_5_2|bool
       - not ubuntu1804cis_skip_for_travis
   tags:
       - level1
@@ -651,7 +651,7 @@
       sysctl_set: true
       ignoreerrors: true
   when:
-      - ubuntu1804cis_rule_1_5_3
+      - ubuntu1804cis_rule_1_5_3|bool
   tags:
       - level1
       - scored
@@ -663,7 +663,7 @@
   command: prelink -ua
   when:
       - prelink_installed.rc == 0
-      - ubuntu1804cis_rule_1_5_4
+      - ubuntu1804cis_rule_1_5_4|bool
   tags:
       - level1
       - scored
@@ -675,7 +675,7 @@
       name: prelink
       state: absent
   when:
-      - ubuntu1804cis_rule_1_5_4
+      - ubuntu1804cis_rule_1_5_4|bool
   tags:
       - level1
       - scored
@@ -691,7 +691,7 @@
   ignore_errors: true
   notify: generate new grub config
   when:
-      - ubuntu1804cis_rule_1_6_1_1
+      - ubuntu1804cis_rule_1_6_1_1|bool
   tags:
       - level2
       - scored
@@ -702,7 +702,7 @@
   command: /bin/true
   changed_when: false
   when:
-      - ubuntu1804cis_rule_1_6_1_2
+      - ubuntu1804cis_rule_1_6_1_2|bool
   tags:
       - level1
       - scored
@@ -714,7 +714,7 @@
   command: /bin/true
   changed_when: false
   when:
-      - ubuntu1804cis_rule_1_6_1_3
+      - ubuntu1804cis_rule_1_6_1_3|bool
   tags:
       - level1
       - scored
@@ -726,7 +726,7 @@
   command: /bin/true
   changed_when: false
   when:
-      - ubuntu1804cis_rule_1_6_1_4
+      - ubuntu1804cis_rule_1_6_1_4|bool
   tags:
       - level1
       - scored
@@ -738,7 +738,7 @@
   command: /bin/true
   changed_when: false
   when:
-      - ubuntu1804cis_rule_1_6_2_1
+      - ubuntu1804cis_rule_1_6_2_1|bool
   tags:
       - level1
       - scored
@@ -750,7 +750,7 @@
   command: /bin/true
   changed_when: false
   when:
-      - ubuntu1804cis_rule_1_6_2_2
+      - ubuntu1804cis_rule_1_6_2_2|bool
   tags:
       - level1
       - scored
@@ -762,7 +762,7 @@
   command: /bin/true
   changed_when: false
   when:
-      - ubuntu1804cis_rule_1_6_3
+      - ubuntu1804cis_rule_1_6_3|bool
   tags:
       - level1
       - scored
@@ -776,7 +776,7 @@
       src: etc/motd.j2
       dest: /etc/motd
   when:
-      - ubuntu1804cis_rule_1_7_1_1
+      - ubuntu1804cis_rule_1_7_1_1|bool
   tags:
       - level1
       - scored
@@ -789,7 +789,7 @@
       src: etc/issue.j2
       dest: /etc/issue
   when:
-      - ubuntu1804cis_rule_1_7_1_2
+      - ubuntu1804cis_rule_1_7_1_2|bool
   tags:
       - level1
       - notscored
@@ -802,7 +802,7 @@
       src: etc/issue.net.j2
       dest: /etc/issue.net
   when:
-      - ubuntu1804cis_rule_1_7_1_3
+      - ubuntu1804cis_rule_1_7_1_3|bool
   tags:
       - level1
       - notscored
@@ -818,7 +818,7 @@
       group: root
       mode: 0644
   when:
-      - ubuntu1804cis_rule_1_7_1_4
+      - ubuntu1804cis_rule_1_7_1_4|bool
   tags:
       - level1
       - notscored
@@ -834,7 +834,7 @@
       group: root
       mode: 0644
   when:
-      - ubuntu1804cis_rule_1_7_1_5
+      - ubuntu1804cis_rule_1_7_1_5|bool
   tags:
       - level1
       - scored
@@ -850,7 +850,7 @@
       group: root
       mode: 0644
   when:
-      - ubuntu1804cis_rule_1_7_1_6
+      - ubuntu1804cis_rule_1_7_1_6|bool
   tags:
       - level1
       - notscored
@@ -876,8 +876,8 @@
       - { file: '/etc/dconf/db/gdm.d/01-banner-message', regexp: 'banner-message-enable', line: 'banner-message-enable=true' }
       - { file: '/etc/dconf/db/gdm.d/01-banner-message', regexp: 'banner-message-text', line: "banner-message-text='{{ ubuntu1804cis_warning_banner }}' " }
   when:
-      - ubuntu1804cis_gui
-      - ubuntu1804cis_rule_1_7_2
+      - ubuntu1804cis_gui|bool
+      - ubuntu1804cis_rule_1_7_2|bool
   tags:
       - level1
       - scored

--- a/tasks/section2.yml
+++ b/tasks/section2.yml
@@ -27,7 +27,7 @@
         when:
             - chargen_stream_service.stat.exists
   when:
-      - ubuntu1804cis_rule_2_1_1
+      - ubuntu1804cis_rule_2_1_1|bool
   tags:
       - level1
       - scored
@@ -64,7 +64,7 @@
         when:
             - daytime_stream_service.stat.exists
   when:
-      - ubuntu1804cis_rule_2_1_2
+      - ubuntu1804cis_rule_2_1_2|bool
   tags:
       - level1
       - scored
@@ -100,7 +100,7 @@
         when:
             - discard_stream_service.stat.exists
   when:
-      - ubuntu1804cis_rule_2_1_3
+      - ubuntu1804cis_rule_2_1_3|bool
   tags:
       - level1
       - scored
@@ -136,7 +136,7 @@
         when:
             - echo_stream_service.stat.exists
   when:
-      - ubuntu1804cis_rule_2_1_4
+      - ubuntu1804cis_rule_2_1_4|bool
   tags:
       - level1
       - scored
@@ -172,7 +172,7 @@
         when:
             - time_stream_service.stat.exists
   when:
-      - ubuntu1804cis_rule_2_1_5
+      - ubuntu1804cis_rule_2_1_5|bool
   tags:
       - level1
       - scored
@@ -190,7 +190,7 @@
         when:
           - not ubuntu1804cis_rsh_server
           - rsh_service_status.stdout == "loaded"
-          - ubuntu1804cis_rule_2_1_6
+          - ubuntu1804cis_rule_2_1_6|bool
 
       - name: "SCORED | 2.1.6 | PATCH | Ensure rsh server is not enabled | rlogin"
         service:
@@ -200,7 +200,7 @@
         when:
           - not ubuntu1804cis_rsh_server
           - rlogin_service_status.stdout == "loaded"
-          - ubuntu1804cis_rule_2_1_6
+          - ubuntu1804cis_rule_2_1_6|bool
 
       - name: "SCORED | 2.1.6 | PATCH | Ensure rsh server is not enabled | rexec"
         service:
@@ -210,7 +210,7 @@
         when:
           - not ubuntu1804cis_rsh_server
           - rexec_service_status.stdout == "loaded"
-          - ubuntu1804cis_rule_2_1_6
+          - ubuntu1804cis_rule_2_1_6|bool
   tags:
     - level1
     - scored
@@ -225,7 +225,7 @@
   when:
     - not ubuntu1804cis_ntalk_server
     - ntalk_service_status.stdout == "loaded"
-    - ubuntu1804cis_rule_2_1_7
+    - ubuntu1804cis_rule_2_1_7|bool
   tags:
     - level1
     - scored
@@ -240,7 +240,7 @@
   when:
     - not ubuntu1804cis_telnet_server
     - telnet_service_status.stdout == "loaded"
-    - ubuntu1804cis_rule_2_1_8
+    - ubuntu1804cis_rule_2_1_8|bool
   tags:
     - level1
     - scored
@@ -266,7 +266,7 @@
         tags:
             - skip_ansible_lint
   when:
-      - ubuntu1804cis_rule_2_1_9
+      - ubuntu1804cis_rule_2_1_9|bool
   tags:
       - level1
       - scored
@@ -281,7 +281,7 @@
   when:
       - xinetd_service_status.stdout == "loaded"
       - not ubuntu1804cis_xinetd_required
-      - ubuntu1804cis_rule_2_1_10
+      - ubuntu1804cis_rule_2_1_10|bool
   tags:
       - level1
       - patch
@@ -294,7 +294,7 @@
     state: absent
   when:
     - openbsd_inetd_service_status.stdout == "ok installed"
-    - ubuntu1804cis_rule_2_1_11
+    - ubuntu1804cis_rule_2_1_11|bool
   tags:
     - level1
     - patch
@@ -335,7 +335,7 @@
             - chronyd_service_status.stdout == "loaded"
 
   when:
-      - ubuntu1804cis_rule_2_2_1_1
+      - ubuntu1804cis_rule_2_2_1_1|bool
   tags:
       - level1
       - notscored
@@ -360,7 +360,7 @@
             line: "RUNASUSER=ntp"
   when:
       - ubuntu1804cis_time_synchronization == "ntp"
-      - ubuntu1804cis_rule_2_2_1_2
+      - ubuntu1804cis_rule_2_2_1_2|bool
   tags:
       - level1
       - scored
@@ -377,7 +377,7 @@
       mode: 0644
   when:
       - ubuntu1804cis_time_synchronization == "chrony"
-      - ubuntu1804cis_rule_2_2_1_3
+      - ubuntu1804cis_rule_2_2_1_3|bool
   tags:
       - level1
       - scored
@@ -395,7 +395,7 @@
       create: true
   when:
       - ubuntu1804cis_time_synchronization == "chrony"
-      - ubuntu1804cis_rule_2_2_1_3
+      - ubuntu1804cis_rule_2_2_1_3|bool
   tags:
       - level1
       - scored
@@ -412,7 +412,7 @@
       state: absent
   when:
       - not ubuntu1804cis_xwindows_required
-      - ubuntu1804cis_rule_2_2_2
+      - ubuntu1804cis_rule_2_2_2|bool
   tags:
       - level1
       - scored
@@ -428,7 +428,7 @@
   when:
       - not ubuntu1804cis_avahi_server
       - avahi_service_status.stdout == "loaded"
-      - ubuntu1804cis_rule_2_2_3
+      - ubuntu1804cis_rule_2_2_3|bool
   tags:
       - level1
       - scored
@@ -445,7 +445,7 @@
   when:
       - not ubuntu1804cis_cups_server
       - cups_service_status.stdout == "loaded"
-      - ubuntu1804cis_rule_2_2_4
+      - ubuntu1804cis_rule_2_2_4|bool
   tags:
       - level1
       - scored
@@ -462,7 +462,7 @@
   when:
       - not ubuntu1804cis_dhcp_server
       - dhcpd_service_status.stdout == "loaded"
-      - ubuntu1804cis_rule_2_2_5
+      - ubuntu1804cis_rule_2_2_5|bool
   tags:
       - level1
       - scored
@@ -479,7 +479,7 @@
   when:
       - not ubuntu1804cis_ldap_server
       - slapd_service_status.stdout == "loaded"
-      - ubuntu1804cis_rule_2_2_6
+      - ubuntu1804cis_rule_2_2_6|bool
   tags:
       - level1
       - scored
@@ -496,7 +496,7 @@
   when:
       - not ubuntu1804cis_nfs_rpc_server
       - nfs_service_status.stdout == "loaded"
-      - ubuntu1804cis_rule_2_2_7
+      - ubuntu1804cis_rule_2_2_7|bool
   tags:
       - level1
       - scored
@@ -514,7 +514,7 @@
   when:
       - not ubuntu1804cis_nfs_rpc_server
       - rpcbind_service_status.stdout == "loaded"
-      - ubuntu1804cis_rule_2_2_7
+      - ubuntu1804cis_rule_2_2_7|bool
   tags:
       - level1
       - scored
@@ -532,7 +532,7 @@
   when:
       - not ubuntu1804cis_named_server
       - named_service_status.stdout == "loaded"
-      - ubuntu1804cis_rule_2_2_8
+      - ubuntu1804cis_rule_2_2_8|bool
   tags:
       - level1
       - scored
@@ -547,7 +547,7 @@
   when:
       - not ubuntu1804cis_vsftpd_server
       - vsftpd_service_status.stdout == "loaded"
-      - ubuntu1804cis_rule_2_2_9
+      - ubuntu1804cis_rule_2_2_9|bool
   tags:
       - level1
       - scored
@@ -562,7 +562,7 @@
   when:
       - not ubuntu1804cis_httpd_server
       - httpd_service_status.stdout == "loaded"
-      - ubuntu1804cis_rule_2_2_10
+      - ubuntu1804cis_rule_2_2_10|bool
   tags:
       - level1
       - scored
@@ -577,7 +577,7 @@
   when:
       - not ubuntu1804cis_dovecot_server
       - dovecot_service_status.stdout == "loaded"
-      - ubuntu1804cis_rule_2_2_11
+      - ubuntu1804cis_rule_2_2_11|bool
   tags:
       - level1
       - scored
@@ -592,7 +592,7 @@
   when:
       - not ubuntu1804cis_smb_server
       - smb_service_status.stdout == "loaded"
-      - ubuntu1804cis_rule_2_2_12
+      - ubuntu1804cis_rule_2_2_12|bool
   tags:
       - level1
       - scored
@@ -607,7 +607,7 @@
   when:
       - not ubuntu1804cis_squid_server
       - squid_service_status.stdout == "loaded"
-      - ubuntu1804cis_rule_2_2_13
+      - ubuntu1804cis_rule_2_2_13|bool
   tags:
       - level1
       - scored
@@ -622,7 +622,7 @@
   when:
       - not ubuntu1804cis_snmp_server
       - snmpd_service_status.stdout == "loaded"
-      - ubuntu1804cis_rule_2_2_14
+      - ubuntu1804cis_rule_2_2_14|bool
   tags:
       - level1
       - scored
@@ -637,7 +637,7 @@
   when:
       - not ubuntu1804cis_is_mail_server
       - postfix_installed.rc == 0
-      - ubuntu1804cis_rule_2_2_15
+      - ubuntu1804cis_rule_2_2_15|bool
   tags:
       - level1
       - scored
@@ -652,7 +652,7 @@
   when:
     - not ubuntu1804cis_rsyncd_server
     - rsyncd_service_status.stdout == "loaded"
-    - ubuntu1804cis_rule_2_2_16
+    - ubuntu1804cis_rule_2_2_16|bool
   tags:
     - level1
     - scored
@@ -667,7 +667,7 @@
   when:
       - not ubuntu1804cis_nis_server
       - ypserv_service_status.stdout == "loaded"
-      - ubuntu1804cis_rule_2_2_17
+      - ubuntu1804cis_rule_2_2_17|bool
   tags:
       - level1
       - scored
@@ -680,7 +680,7 @@
       state: absent
   when:
       - not ubuntu1804cis_ypbind_required
-      - ubuntu1804cis_rule_2_3_1
+      - ubuntu1804cis_rule_2_3_1|bool
   tags:
       - level1
       - scored
@@ -693,7 +693,7 @@
       state: absent
   when:
       - not ubuntu1804cis_rsh_required
-      - ubuntu1804cis_rule_2_3_2
+      - ubuntu1804cis_rule_2_3_2|bool
   tags:
       - level1
       - scored
@@ -706,7 +706,7 @@
       state: absent
   when:
       - not ubuntu1804cis_talk_required
-      - ubuntu1804cis_rule_2_3_3
+      - ubuntu1804cis_rule_2_3_3|bool
   tags:
       - level1
       - scored
@@ -719,7 +719,7 @@
       state: absent
   when:
       - not ubuntu1804cis_telnet_required
-      - ubuntu1804cis_rule_2_3_4
+      - ubuntu1804cis_rule_2_3_4|bool
   tags:
       - level1
       - scored
@@ -732,7 +732,7 @@
       state: absent
   when:
       - not ubuntu1804cis_openldap_clients_required
-      - ubuntu1804cis_rule_2_3_5
+      - ubuntu1804cis_rule_2_3_5|bool
   tags:
       - level1
       - scored

--- a/tasks/section3.yml
+++ b/tasks/section3.yml
@@ -196,7 +196,7 @@
   with_items:
       - { name: net.ipv6.conf.all.accept_ra, value: 0 }
       - { name: net.ipv6.conf.default.accept_ra, value: 0 }
-  when: ubuntu1804cis_ipv6_required
+  when: ubuntu1804cis_ipv6_required|bool
   notify:
       - sysctl flush ipv6 route table
   tags:
@@ -217,7 +217,7 @@
   with_items:
       - { name: net.ipv6.conf.all.accept_redirects, value: 0 }
       - { name: net.ipv6.conf.default.accept_redirects, value: 0 }
-  when: ubuntu1804cis_ipv6_required
+  when: ubuntu1804cis_ipv6_required|bool
   notify:
       - sysctl flush ipv6 route table
   tags:
@@ -354,7 +354,7 @@
       install_recommends: false
   when:
       - ubuntu1804cis_firewall == "firewalld"
-      - ubuntu1804cis_setup_firewall
+      - ubuntu1804cis_setup_firewall|bool
   tags:
       - level1
       - scored
@@ -368,7 +368,7 @@
       enabled: true
   when:
       - ubuntu1804cis_firewall == "firewalld"
-      - ubuntu1804cis_setup_firewall
+      - ubuntu1804cis_setup_firewall|bool
   tags:
       - level1
       - scored
@@ -382,7 +382,7 @@
       install_recommends: false
   when:
       - ubuntu1804cis_firewall == "iptables"
-      - ubuntu1804cis_setup_firewall
+      - ubuntu1804cis_setup_firewall|bool
   tags:
       - level1
       - scored
@@ -396,7 +396,7 @@
       enabled: true
   when:
       - ubuntu1804cis_firewall == "iptables"
-      - ubuntu1804cis_setup_firewall
+      - ubuntu1804cis_setup_firewall|bool
   tags:
       - level1
       - scored
@@ -410,7 +410,7 @@
       line: "DefaultZone=drop"
   when:
       - ubuntu1804cis_firewall == "firewalld"
-      - ubuntu1804cis_setup_firewall
+      - ubuntu1804cis_setup_firewall|bool
   tags:
       - level1
       - scored
@@ -424,7 +424,7 @@
       permanent: true
   when:
       - ubuntu1804cis_firewall == "firewalld"
-      - ubuntu1804cis_setup_firewall
+      - ubuntu1804cis_setup_firewall|bool
   tags:
       - level1
       - scored
@@ -436,7 +436,7 @@
   changed_when: false
   when:
       - ubuntu1804cis_firewall == "iptables"
-      - ubuntu1804cis_setup_firewall
+      - ubuntu1804cis_setup_firewall|bool
   tags:
       - level1
       - scored
@@ -449,7 +449,7 @@
   changed_when: false
   when:
       - ubuntu1804cis_firewall == "iptables"
-      - ubuntu1804cis_setup_firewall
+      - ubuntu1804cis_setup_firewall|bool
   tags:
       - level1
       - scored
@@ -462,7 +462,7 @@
   changed_when: false
   when:
       - ubuntu1804cis_firewall == "iptables"
-      - ubuntu1804cis_setup_firewall
+      - ubuntu1804cis_setup_firewall|bool
   tags:
       - level1
       - notscored
@@ -479,7 +479,7 @@
       immediate: true
   when:
       - ubuntu1804cis_firewall == "firewalld"
-      - ubuntu1804cis_setup_firewall
+      - ubuntu1804cis_setup_firewall|bool
   notify: restart firewalld
   with_items: "{{ ubuntu1804cis_firewall_services }}"
   tags:
@@ -493,7 +493,7 @@
   changed_when: false
   when:
       - ubuntu1804cis_firewall == "iptables"
-      - ubuntu1804cis_setup_firewall
+      - ubuntu1804cis_setup_firewall|bool
   tags:
       - level1
       - scored

--- a/tasks/section4.yml
+++ b/tasks/section4.yml
@@ -6,7 +6,7 @@
       line: "max_log_file = 10"
       state: present
   when:
-      - ubuntu1804cis_rule_4_1_1_1
+      - ubuntu1804cis_rule_4_1_1_1|bool
   notify:
       - restart auditd
   tags:
@@ -23,7 +23,7 @@
       line: "admin_space_left_action = {{ ubuntu1804cis_auditd['admin_space_left_action'] }}"
       state: present
   when:
-      - ubuntu1804cis_rule_4_1_1_2
+      - ubuntu1804cis_rule_4_1_1_2|bool
   notify:
       - restart auditd
   tags:
@@ -40,7 +40,7 @@
       line: "space_left_action = email"
       state: present
   when:
-      - ubuntu1804cis_rule_4_1_1_2
+      - ubuntu1804cis_rule_4_1_1_2|bool
   notify:
       - restart auditd
   tags:
@@ -57,7 +57,7 @@
       line: "max_log_file_action = {{ ubuntu1804cis_auditd['max_log_file_action'] }}"
       state: present
   when:
-      - ubuntu1804cis_rule_4_1_1_3
+      - ubuntu1804cis_rule_4_1_1_3|bool
   notify:
       - restart auditd
   tags:
@@ -74,7 +74,7 @@
       enabled: true
   when:
       - not ubuntu1804cis_skip_for_travis
-      - ubuntu1804cis_rule_4_1_2
+      - ubuntu1804cis_rule_4_1_2|bool
   tags:
       - level2
       - scored
@@ -92,7 +92,7 @@
   notify:
       - generate new grub config
   when:
-      - ubuntu1804cis_rule_4_1_3
+      - ubuntu1804cis_rule_4_1_3|bool
   tags:
       - level2
       - scored
@@ -108,7 +108,7 @@
       group: root
       mode: 0600
   when:
-      - ubuntu1804cis_rule_4_1_4
+      - ubuntu1804cis_rule_4_1_4|bool
   notify:
       - load audit rules
       - restart auditd
@@ -127,7 +127,7 @@
       group: root
       mode: 0600
   when:
-      - ubuntu1804cis_rule_4_1_5
+      - ubuntu1804cis_rule_4_1_5|bool
   notify:
       - load audit rules
       - restart auditd
@@ -146,7 +146,7 @@
       group: root
       mode: 0600
   when:
-      - ubuntu1804cis_rule_4_1_6
+      - ubuntu1804cis_rule_4_1_6|bool
   notify:
       - load audit rules
       - restart auditd
@@ -165,7 +165,7 @@
       group: root
       mode: 0600
   when:
-      - ubuntu1804cis_rule_4_1_7
+      - ubuntu1804cis_rule_4_1_7|bool
   notify:
       - load audit rules
       - restart auditd
@@ -184,7 +184,7 @@
       group: root
       mode: 0600
   when:
-      - ubuntu1804cis_rule_4_1_8
+      - ubuntu1804cis_rule_4_1_8|bool
   notify:
       - load audit rules
       - restart auditd
@@ -203,7 +203,7 @@
       group: root
       mode: 0600
   when:
-      - ubuntu1804cis_rule_4_1_9
+      - ubuntu1804cis_rule_4_1_9|bool
   notify:
       - load audit rules
       - restart auditd
@@ -222,7 +222,7 @@
       group: root
       mode: 0600
   when:
-      - ubuntu1804cis_rule_4_1_10
+      - ubuntu1804cis_rule_4_1_10|bool
   notify:
       - load audit rules
       - restart auditd
@@ -241,7 +241,7 @@
       group: root
       mode: 0600
   when:
-      - ubuntu1804cis_rule_4_1_11
+      - ubuntu1804cis_rule_4_1_11|bool
   notify:
       - load audit rules
       - restart auditd
@@ -272,7 +272,7 @@
             - load audit rules
             - restart auditd
   when:
-      - ubuntu1804cis_rule_4_1_12
+      - ubuntu1804cis_rule_4_1_12|bool
   tags:
       - level2
       - scored
@@ -288,7 +288,7 @@
       group: root
       mode: 0600
   when:
-      - ubuntu1804cis_rule_4_1_13
+      - ubuntu1804cis_rule_4_1_13|bool
   notify:
       - load audit rules
       - restart auditd
@@ -307,7 +307,7 @@
       group: root
       mode: 0600
   when:
-      - ubuntu1804cis_rule_4_1_14
+      - ubuntu1804cis_rule_4_1_14|bool
   notify:
       - load audit rules
       - restart auditd
@@ -326,7 +326,7 @@
       group: root
       mode: 0600
   when:
-      - ubuntu1804cis_rule_4_1_15
+      - ubuntu1804cis_rule_4_1_15|bool
   notify:
       - load audit rules
       - restart auditd
@@ -345,7 +345,7 @@
       group: root
       mode: 0600
   when:
-      - ubuntu1804cis_rule_4_1_16
+      - ubuntu1804cis_rule_4_1_16|bool
   notify:
       - load audit rules
       - restart auditd
@@ -364,7 +364,7 @@
       group: root
       mode: 0600
   when:
-      - ubuntu1804cis_rule_4_1_17
+      - ubuntu1804cis_rule_4_1_17|bool
   notify:
       - load audit rules
       - restart auditd
@@ -383,7 +383,7 @@
       group: root
       mode: 0600
   when:
-      - ubuntu1804cis_rule_4_1_18
+      - ubuntu1804cis_rule_4_1_18|bool
   notify:
       - load audit rules
       - restart auditd
@@ -401,7 +401,7 @@
       state: present
       install_recommends: false
   when:
-      - ubuntu1804cis_rule_4_2_3
+      - ubuntu1804cis_rule_4_2_3|bool
   tags:
       - level1
       - scored
@@ -415,7 +415,7 @@
       enabled: yes
   changed_when: false
   when:
-      - ubuntu1804cis_rule_4_2_1_1
+      - ubuntu1804cis_rule_4_2_1_1|bool
       - ubuntu1804cis_syslog == "rsyslog"
   tags:
       - level1
@@ -428,7 +428,7 @@
   command: /bin/true
   changed_when: false
   when:
-      - ubuntu1804cis_rule_4_2_1_2
+      - ubuntu1804cis_rule_4_2_1_2|bool
   tags:
       - level1
       - notscored
@@ -443,7 +443,7 @@
       regexp: '^\$FileCreateMode'
       line: '$FileCreateMode 0640'
   when:
-      - ubuntu1804cis_rule_4_2_1_3
+      - ubuntu1804cis_rule_4_2_1_3|bool
   tags:
       - level1
       - scored
@@ -455,7 +455,7 @@
   command: /bin/true
   changed_when: false
   when:
-      - ubuntu1804cis_rule_4_2_1_4
+      - ubuntu1804cis_rule_4_2_1_4|bool
   tags:
       - level1
       - scored
@@ -468,7 +468,7 @@
   command: /bin/true
   changed_when: false
   when:
-      - ubuntu1804cis_rule_4_2_1_5
+      - ubuntu1804cis_rule_4_2_1_5|bool
   tags:
       - level1
       - notscored
@@ -481,7 +481,7 @@
   command: /bin/true
   changed_when: false
   when:
-      - ubuntu1804cis_rule_4_2_1_5
+      - ubuntu1804cis_rule_4_2_1_5|bool
   tags:
       - level1
       - notscored
@@ -494,7 +494,7 @@
   command: /bin/true
   changed_when: false
   when:
-      - ubuntu1804cis_rule_4_2_2_1
+      - ubuntu1804cis_rule_4_2_2_1|bool
   tags:
       - level1
       - scored
@@ -507,7 +507,7 @@
   command: /bin/true
   changed_when: false
   when:
-      - ubuntu1804cis_rule_4_2_2_2
+      - ubuntu1804cis_rule_4_2_2_2|bool
   tags:
       - level1
       - notscored
@@ -520,7 +520,7 @@
   command: /bin/true
   changed_when: false
   when:
-      - ubuntu1804cis_rule_4_2_2_3
+      - ubuntu1804cis_rule_4_2_2_3|bool
   tags:
       - level1
       - scored
@@ -533,7 +533,7 @@
   command: /bin/true
   changed_when: false
   when:
-      - ubuntu1804cis_rule_4_2_2_4
+      - ubuntu1804cis_rule_4_2_2_4|bool
   tags:
       - level1
       - notscored
@@ -546,7 +546,7 @@
   command: /bin/true
   changed_when: false
   when:
-      - ubuntu1804cis_rule_4_2_2_5
+      - ubuntu1804cis_rule_4_2_2_5|bool
   tags:
       - level1
       - notscored
@@ -560,7 +560,7 @@
   changed_when: false
   failed_when: false
   when:
-      - ubuntu1804cis_rule_4_2_4
+      - ubuntu1804cis_rule_4_2_4|bool
   tags:
       - level1
       - scored
@@ -590,7 +590,7 @@
             - "{{ log_rotates.files }}"
             - { path: "/etc/logrotate.conf" }
   when:
-      - ubuntu1804cis_rule_4_3
+      - ubuntu1804cis_rule_4_3|bool
   tags:
       - level1
       - notscored

--- a/tasks/section5.yml
+++ b/tasks/section5.yml
@@ -4,7 +4,7 @@
       name: "{{ cron_service[ansible_os_family] }}"
       enabled: true
   when:
-      - ubuntu1804cis_rule_5_1_1
+      - ubuntu1804cis_rule_5_1_1|bool
   tags:
       - level1
       - scored
@@ -19,7 +19,7 @@
       group: root
       mode: 0600
   when:
-      - ubuntu1804cis_rule_5_1_2
+      - ubuntu1804cis_rule_5_1_2|bool
   tags:
       - level1
       - scored
@@ -35,7 +35,7 @@
       group: root
       mode: 0700
   when:
-      - ubuntu1804cis_rule_5_1_3
+      - ubuntu1804cis_rule_5_1_3|bool
   tags:
       - level1
       - scored
@@ -51,7 +51,7 @@
       group: root
       mode: 0700
   when:
-      - ubuntu1804cis_rule_5_1_4
+      - ubuntu1804cis_rule_5_1_4|bool
   tags:
       - level1
       - scored
@@ -67,7 +67,7 @@
       group: root
       mode: 0700
   when:
-      - ubuntu1804cis_rule_5_1_5
+      - ubuntu1804cis_rule_5_1_5|bool
   tags:
       - level1
       - scored
@@ -83,7 +83,7 @@
       group: root
       mode: 0700
   when:
-      - ubuntu1804cis_rule_5_1_6
+      - ubuntu1804cis_rule_5_1_6|bool
   tags:
       - level1
       - scored
@@ -99,7 +99,7 @@
       group: root
       mode: 0700
   when:
-      - ubuntu1804cis_rule_5_1_7
+      - ubuntu1804cis_rule_5_1_7|bool
   tags:
       - level1
       - scored
@@ -145,7 +145,7 @@
             group: root
             mode: 0600
   when:
-      - ubuntu1804cis_rule_5_1_8
+      - ubuntu1804cis_rule_5_1_8|bool
   tags:
       - level1
       - scored
@@ -161,7 +161,7 @@
       group: root
       mode: 0600
   when:
-      - ubuntu1804cis_rule_5_2_1
+      - ubuntu1804cis_rule_5_2_1|bool
   tags:
       - level1
       - scored
@@ -176,7 +176,7 @@
       regexp: '^Protocol'
       line: 'Protocol 2'
   when:
-      - ubuntu1804cis_rule_5_2_2
+      - ubuntu1804cis_rule_5_2_2|bool
   tags:
       - level1
       - scored
@@ -191,7 +191,7 @@
       regexp: '^LogLevel'
       line: 'LogLevel INFO'
   when:
-      - ubuntu1804cis_rule_5_2_3
+      - ubuntu1804cis_rule_5_2_3|bool
   tags:
       - level1
       - scored
@@ -206,7 +206,7 @@
       regexp: '^X11Forwarding'
       line: 'X11Forwarding no'
   when:
-      - ubuntu1804cis_rule_5_2_4
+      - ubuntu1804cis_rule_5_2_4|bool
   tags:
       - level1
       - scored
@@ -221,7 +221,7 @@
       regexp: '^(#)?MaxAuthTries \d'
       line: 'MaxAuthTries 4'
   when:
-      - ubuntu1804cis_rule_5_2_5
+      - ubuntu1804cis_rule_5_2_5|bool
   tags:
       - level1
       - scored
@@ -236,7 +236,7 @@
       regexp: '^IgnoreRhosts'
       line: 'IgnoreRhosts yes'
   when:
-      - ubuntu1804cis_rule_5_2_6
+      - ubuntu1804cis_rule_5_2_6|bool
   tags:
       - level1
       - scored
@@ -251,7 +251,7 @@
       regexp: '^HostbasedAuthentication'
       line: 'HostbasedAuthentication no'
   when:
-      - ubuntu1804cis_rule_5_2_7
+      - ubuntu1804cis_rule_5_2_7|bool
   tags:
       - level1
       - scored
@@ -266,7 +266,7 @@
       regexp: '^PermitRootLogin'
       line: 'PermitRootLogin no'
   when:
-      - ubuntu1804cis_rule_5_2_8
+      - ubuntu1804cis_rule_5_2_8|bool
   tags:
       - level1
       - scored
@@ -281,7 +281,7 @@
       regexp: '^PermitEmptyPasswords'
       line: 'PermitEmptyPasswords no'
   when:
-      - ubuntu1804cis_rule_5_2_9
+      - ubuntu1804cis_rule_5_2_9|bool
   tags:
       - level1
       - scored
@@ -296,7 +296,7 @@
       regexp: '^PermitUserEnvironment'
       line: 'PermitUserEnvironment no'
   when:
-      - ubuntu1804cis_rule_5_2_10
+      - ubuntu1804cis_rule_5_2_10|bool
   tags:
       - level1
       - scored
@@ -311,7 +311,7 @@
       regexp: '^MACs'
       line: 'MACs hmac-sha2-512-etm@openssh.com,hmac-sha2-256-etm@openssh.com,umac-128-etm@openssh.com,hmac-sha2-512,hmac-sha2-256,umac-128@openssh.com'
   when:
-      - ubuntu1804cis_rule_5_2_11
+      - ubuntu1804cis_rule_5_2_11|bool
   tags:
       - level1
       - scored
@@ -335,7 +335,7 @@
             regexp: '^ClientAliveCountMax'
             line: "ClientAliveCountMax {{ ubuntu1804cis_sshd['clientalivecountmax'] }}"
   when:
-      - ubuntu1804cis_rule_5_2_12
+      - ubuntu1804cis_rule_5_2_12|bool
   tags:
       - level1
       - scored
@@ -350,7 +350,7 @@
       regexp: '^LoginGraceTime'
       line: "LoginGraceTime 60"
   when:
-      - ubuntu1804cis_rule_5_2_13
+      - ubuntu1804cis_rule_5_2_13|bool
   tags:
       - level1
       - scored
@@ -404,7 +404,7 @@
         when:
             - "ubuntu1804cis_sshd['denygroups']|default('')"
   when:
-      - ubuntu1804cis_rule_5_2_14
+      - ubuntu1804cis_rule_5_2_14|bool
   tags:
       - level1
       - scored
@@ -419,7 +419,7 @@
       regexp: '^Banner'
       line: 'Banner /etc/issue.net'
   when:
-      - ubuntu1804cis_rule_5_2_15
+      - ubuntu1804cis_rule_5_2_15|bool
   tags:
       - level1
       - scored
@@ -444,7 +444,7 @@
         with_items:
             - "{{ ubuntu1804cis_pwquality }}"
   when:
-      - ubuntu1804cis_rule_5_3_1
+      - ubuntu1804cis_rule_5_3_1|bool
   tags:
       - level1
       - scored
@@ -455,7 +455,7 @@
   command: /bin/true
   changed_when: false
   when:
-      - ubuntu1804cis_rule_5_3_2
+      - ubuntu1804cis_rule_5_3_2|bool
   tags:
       - level1
       - scored
@@ -467,7 +467,7 @@
   command: /bin/true
   changed_when: false
   when:
-      - ubuntu1804cis_rule_5_3_3
+      - ubuntu1804cis_rule_5_3_3|bool
   tags:
       - level1
       - scored
@@ -480,7 +480,7 @@
   changed_when: false
   failed_when: false
   when:
-      - ubuntu1804cis_rule_5_3_4
+      - ubuntu1804cis_rule_5_3_4|bool
   tags:
       - level1
       - scored
@@ -494,7 +494,7 @@
       regexp: '^PASS_MAX_DAYS'
       line: "PASS_MAX_DAYS {{ ubuntu1804cis_pass['max_days'] }}"
   when:
-      - ubuntu1804cis_rule_5_4_1_1
+      - ubuntu1804cis_rule_5_4_1_1|bool
   tags:
       - level1
       - scored
@@ -508,7 +508,7 @@
       regexp: '^PASS_MIN_DAYS'
       line: "PASS_MIN_DAYS {{ ubuntu1804cis_pass['min_days'] }}"
   when:
-      - ubuntu1804cis_rule_5_4_1_2
+      - ubuntu1804cis_rule_5_4_1_2|bool
   tags:
       - level1
       - scored
@@ -522,7 +522,7 @@
       regexp: '^PASS_WARN_AGE'
       line: "PASS_WARN_AGE {{ ubuntu1804cis_pass['warn_age'] }}"
   when:
-      - ubuntu1804cis_rule_5_4_1_3
+      - ubuntu1804cis_rule_5_4_1_3|bool
   tags:
       - level1
       - scored
@@ -533,7 +533,7 @@
   command: /bin/true
   changed_when: false
   when:
-      - ubuntu1804cis_rule_5_4_1_4
+      - ubuntu1804cis_rule_5_4_1_4|bool
   tags:
       - level1
       - scored
@@ -554,7 +554,7 @@
     done
   changed_when: false
   when:
-      - ubuntu1804cis_rule_5_4_2
+      - ubuntu1804cis_rule_5_4_2|bool
       - system_accounts_non_login_1.stdout
       - system_accounts_non_login_2.stdout
   tags:
@@ -568,7 +568,7 @@
   changed_when: false
   failed_when: false
   when:
-      - ubuntu1804cis_rule_5_4_3
+      - ubuntu1804cis_rule_5_4_3|bool
   tags:
       - level1
       - patch
@@ -596,7 +596,7 @@
             regexp: '(^\s+umask) 002'
             replace: '\1 027'
   when:
-      - ubuntu1804cis_rule_5_4_4
+      - ubuntu1804cis_rule_5_4_4|bool
   tags:
       - level1
       - patch
@@ -607,7 +607,7 @@
   command: /bin/true
   changed_when: false
   when:
-      - ubuntu1804cis_rule_5_5
+      - ubuntu1804cis_rule_5_5|bool
   tags:
       - level1
       - patch
@@ -622,7 +622,7 @@
       regexp: '^(#)?auth\s+required\s+pam_wheel\.so'
       line: "auth           required        pam_wheel.so use_uid"
   when:
-      - ubuntu1804cis_rule_5_6
+      - ubuntu1804cis_rule_5_6|bool
   tags:
       - level1
       - patch
@@ -634,7 +634,7 @@
       name: root
       groups: sudo
   when:
-      - ubuntu1804cis_rule_5_6
+      - ubuntu1804cis_rule_5_6|bool
   tags:
       - level1
       - patch

--- a/tasks/section6.yml
+++ b/tasks/section6.yml
@@ -3,7 +3,7 @@
   command: /bin/true
   changed_when: false
   when:
-      - ubuntu1804cis_rule_6_1_1
+      - ubuntu1804cis_rule_6_1_1|bool
   tags:
       - level2
       - notscored
@@ -18,7 +18,7 @@
       group: root
       mode: 0644
   when:
-      - ubuntu1804cis_rule_6_1_2
+      - ubuntu1804cis_rule_6_1_2|bool
   tags:
       - level1
       - scored
@@ -32,7 +32,7 @@
       group: shadow
       mode: 0640
   when:
-      - ubuntu1804cis_rule_6_1_3
+      - ubuntu1804cis_rule_6_1_3|bool
   tags:
       - level1
       - scored
@@ -46,7 +46,7 @@
       group: root
       mode: 0644
   when:
-      - ubuntu1804cis_rule_6_1_4
+      - ubuntu1804cis_rule_6_1_4|bool
   tags:
       - level1
       - scored
@@ -60,7 +60,7 @@
       group: shadow
       mode: 0640
   when:
-      - ubuntu1804cis_rule_6_1_5
+      - ubuntu1804cis_rule_6_1_5|bool
   tags:
       - level1
       - scored
@@ -74,7 +74,7 @@
       group: root
       mode: 0644
   when:
-      - ubuntu1804cis_rule_6_1_6
+      - ubuntu1804cis_rule_6_1_6|bool
   tags:
       - level1
       - scored
@@ -88,7 +88,7 @@
       group: shadow
       mode: 0640
   when:
-      - ubuntu1804cis_rule_6_1_7
+      - ubuntu1804cis_rule_6_1_7|bool
   tags:
       - level1
       - scored
@@ -102,7 +102,7 @@
       group: root
       mode: 0644
   when:
-      - ubuntu1804cis_rule_6_1_8
+      - ubuntu1804cis_rule_6_1_8|bool
   tags:
       - level1
       - scored
@@ -116,7 +116,7 @@
       group: shadow
       mode: 0640
   when:
-      - ubuntu1804cis_rule_6_1_9
+      - ubuntu1804cis_rule_6_1_9|bool
   tags:
       - level1
       - scored
@@ -127,7 +127,7 @@
   command: /bin/true
   changed_when: false
   when:
-      - ubuntu1804cis_rule_6_1_10
+      - ubuntu1804cis_rule_6_1_10|bool
   tags:
       - level1
       - scored
@@ -139,7 +139,7 @@
   command: /bin/true
   changed_when: false
   when:
-      - ubuntu1804cis_rule_6_1_11
+      - ubuntu1804cis_rule_6_1_11|bool
   tags:
       - level1
       - scored
@@ -151,7 +151,7 @@
   command: /bin/true
   changed_when: false
   when:
-      - ubuntu1804cis_rule_6_1_12
+      - ubuntu1804cis_rule_6_1_12|bool
   tags:
       - level1
       - scored
@@ -163,7 +163,7 @@
   command: /bin/true
   changed_when: false
   when:
-      - ubuntu1804cis_rule_6_1_13
+      - ubuntu1804cis_rule_6_1_13|bool
   tags:
       - level1
       - notscored
@@ -175,7 +175,7 @@
   command: /bin/true
   changed_when: false
   when:
-      - ubuntu1804cis_rule_6_1_14
+      - ubuntu1804cis_rule_6_1_14|bool
   tags:
       - level1
       - notscored
@@ -190,7 +190,7 @@
   with_items: "{{ empty_password_accounts.stdout_lines }}"
   when:
       - empty_password_accounts.rc
-      - ubuntu1804cis_rule_6_2_1
+      - ubuntu1804cis_rule_6_2_1|bool
   tags:
       - level1
       - scored
@@ -203,7 +203,7 @@
       state: absent
       path: /etc/passwd
   when:
-      - ubuntu1804cis_rule_6_2_2
+      - ubuntu1804cis_rule_6_2_2|bool
   tags:
       - level1
       - scored
@@ -216,7 +216,7 @@
       state: absent
       path: /etc/shadow
   when:
-      - ubuntu1804cis_rule_6_2_3
+      - ubuntu1804cis_rule_6_2_3|bool
   tags:
       - level1
       - scored
@@ -229,7 +229,7 @@
       state: absent
       path: /etc/group
   when:
-      - ubuntu1804cis_rule_6_2_4
+      - ubuntu1804cis_rule_6_2_4|bool
   tags:
       - level1
       - scored
@@ -243,7 +243,7 @@
   with_items: "{{ uid_zero_accounts_except_root.stdout_lines }}"
   when:
       - uid_zero_accounts_except_root.rc
-      - ubuntu1804cis_rule_6_2_5
+      - ubuntu1804cis_rule_6_2_5|bool
   tags:
       - level1
       - scored
@@ -254,7 +254,7 @@
   command: /bin/true
   changed_when: false
   when:
-      - ubuntu1804cis_rule_6_2_6
+      - ubuntu1804cis_rule_6_2_6|bool
   tags:
       - level1
       - scored
@@ -280,7 +280,7 @@
   changed_when: false
   check_mode: false
   when:
-      - ubuntu1804cis_rule_6_2_6
+      - ubuntu1804cis_rule_6_2_6|bool
   tags:
       - level1
       - scored
@@ -305,7 +305,7 @@
   command: /bin/true
   changed_when: false
   when:
-      - ubuntu1804cis_rule_6_2_7
+      - ubuntu1804cis_rule_6_2_7|bool
   tags:
       - level1
       - scored
@@ -317,7 +317,7 @@
   command: /bin/true
   changed_when: false
   when:
-      - ubuntu1804cis_rule_6_2_8
+      - ubuntu1804cis_rule_6_2_8|bool
   tags:
       - level1
       - scored
@@ -329,7 +329,7 @@
   command: /bin/true
   changed_when: false
   when:
-      - ubuntu1804cis_rule_6_2_9
+      - ubuntu1804cis_rule_6_2_9|bool
   tags:
       - level1
       - scored
@@ -341,7 +341,7 @@
   command: /bin/true
   changed_when: false
   when:
-      - ubuntu1804cis_rule_6_2_10
+      - ubuntu1804cis_rule_6_2_10|bool
   tags:
       - level1
       - scored
@@ -355,7 +355,7 @@
       dest: "~{{ item }}/.forward"
   with_items: "{{ users.stdout_lines }}"
   when:
-      - ubuntu1804cis_rule_6_2_11
+      - ubuntu1804cis_rule_6_2_11|bool
   tags:
       - level1
       - scored
@@ -368,7 +368,7 @@
       dest: "~{{ item }}/.netrc"
   with_items: "{{ users.stdout_lines }}"
   when:
-      - ubuntu1804cis_rule_6_2_12
+      - ubuntu1804cis_rule_6_2_12|bool
   tags:
       - level1
       - scored
@@ -381,7 +381,7 @@
       dest: "~{{ item }}/.rhosts"
   with_items: "{{ users.stdout_lines }}"
   when:
-      - ubuntu1804cis_rule_6_2_14
+      - ubuntu1804cis_rule_6_2_14|bool
   tags:
       - level1
       - scored
@@ -392,7 +392,7 @@
   command: /bin/true
   changed_when: false
   when:
-      - ubuntu1804cis_rule_6_2_15
+      - ubuntu1804cis_rule_6_2_15|bool
   tags:
       - level1
       - scored
@@ -404,7 +404,7 @@
   command: /bin/true
   changed_when: false
   when:
-      - ubuntu1804cis_rule_6_2_16
+      - ubuntu1804cis_rule_6_2_16|bool
   tags:
       - level1
       - scored
@@ -416,7 +416,7 @@
   command: /bin/true
   changed_when: false
   when:
-      - ubuntu1804cis_rule_6_2_17
+      - ubuntu1804cis_rule_6_2_17|bool
   tags:
       - level1
       - scored
@@ -428,7 +428,7 @@
   command: /bin/true
   changed_when: false
   when:
-      - ubuntu1804cis_rule_6_2_18
+      - ubuntu1804cis_rule_6_2_18|bool
   tags:
       - level1
       - scored
@@ -440,7 +440,7 @@
   command: /bin/true
   changed_when: false
   when:
-      - ubuntu1804cis_rule_6_2_19
+      - ubuntu1804cis_rule_6_2_19|bool
   tags:
       - level1
       - scored


### PR DESCRIPTION
# Warning message:

```bash
[DEPRECATION WARNING]: evaluating <VALUE> as a bare variable, this behaviour will go away and you might need to add |bool to the expression in the future. Also see CONDITIONAL_BARE_VARS configuration toggle.. This feature will 
be removed in version 2.12. Deprecation warnings can be disabled by setting deprecation_warnings=False in ansible.cfg.
```

# Proposed solution:

Followed this blog post:
http://blog.dailystuff.nl/2019/06/using-bare-variables-in-ansible-2-8/
