### PR TITLE
Fixing string field typecasting warning

### DIFF
--- a/tasks/section1.yml
+++ b/tasks/section1.yml
@@ -611,7 +611,7 @@
 - name: "SCORED | 1.5.1 | PATCH | Ensure core dumps are restricted"
   sysctl:
       name: fs.suid_dumpable
-      value: 0
+      value: "0"
       state: present
       reload: true
       sysctl_set: true
@@ -645,7 +645,7 @@
 - name: "SCORED | 1.5.3 | PATCH | Ensure address space layout randomization (ASLR) is enabled"
   sysctl:
       name: kernel.randomize_va_space
-      value: 2
+      value: "2"
       state: present
       reload: true
       sysctl_set: true

--- a/tasks/section3.yml
+++ b/tasks/section3.yml
@@ -2,7 +2,7 @@
 - name: "SCORED | 3.1.1 | PATCH | Ensure IP forwarding is disabled"
   sysctl:
       name: net.ipv4.ip_forward
-      value: 0
+      value: "0"
       state: present
       reload: true
       ignoreerrors: true
@@ -136,7 +136,7 @@
 - name: "SCORED | 3.2.6 | PATCH | Ensure bogus ICMP responses are ignored"
   sysctl:
       name: net.ipv4.icmp_ignore_bogus_error_responses
-      value: 1
+      value: "1"
       state: present
       reload: true
       ignoreerrors: true

--- a/tasks/section3.yml
+++ b/tasks/section3.yml
@@ -120,7 +120,7 @@
 - name: "SCORED | 3.2.5 | PATCH | Ensure broadcast ICMP requests are ignored"
   sysctl:
       name: net.ipv4.icmp_echo_ignore_broadcasts
-      value: 1
+      value: "1"
       state: present
       reload: true
       ignoreerrors: true


### PR DESCRIPTION
# Warning message:

```bash
 TASK [Ubuntu1804-CIS : SCORED | 1.5.1 | PATCH | Ensure core dumps are restricted] **************************************************************************************
  [WARNING]: The value 0 (type int) in a string field was converted to '0' (type string). If this does not look like what you expect, quote the entire value to ensure
 it does not change.


 TASK [Ubuntu1804-CIS : SCORED | 1.5.3 | PATCH | Ensure address space layout randomization (ASLR) is enabled] ***********************************************************
  [WARNING]: The value 2 (type int) in a string field was converted to '2' (type string). If this does not look like what you expect, quote the entire value to ensure
 it does not change.


 TASK [Ubuntu1804-CIS : SCORED | 3.2.5 | PATCH | Ensure broadcast ICMP requests are ignored] ****************************************************************************
  [WARNING]: The value 1 (type int) in a string field was converted to '1' (type string). If this does not look like what you expect, quote the entire value to ensure
 it does not change.
```

# Proposed solution:

YAML requires to enclose string values in quotes to avoid integer representation.