### PR TITLE
fix warning:

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -5,7 +5,7 @@
   become: true
   sysctl:
       name: net.ipv4.route.flush
-      value: 1
+      value: "1"
       sysctl_set: true
   when: ansible_virtualization_type != "docker"
 
@@ -13,7 +13,7 @@
   become: true
   sysctl:
       name: net.ipv6.route.flush
-      value: 1
+      value: "1"
       sysctl_set: true
   when: ansible_virtualization_type != "docker"
 

--- a/tasks/post.yml
+++ b/tasks/post.yml
@@ -11,11 +11,10 @@
 
 - name: "POST | Perform apt package cleanup"
   apt:
-    name: "{{ item }}"
+    name: "{{ apt_rc_packages.stdout_lines }}"
     state: absent
     purge: true
   changed_when: false
   ignore_errors: true
-  with_items: "{{ apt_rc_packages.stdout_lines }}"
   tags:
     - skip_ansible_lint

--- a/tasks/section3.yml
+++ b/tasks/section3.yml
@@ -172,7 +172,7 @@
 - name: "SCORED | 3.2.8 | PATCH | Ensure TCP SYN Cookies is enabled"
   sysctl:
       name: net.ipv4.tcp_syncookies
-      value: 1
+      value: '1'
       state: present
       reload: true
       ignoreerrors: true


### PR DESCRIPTION
The value 1 (type int) in a string field was converted to u'1' (type string).
And remove deprecated loop:
Invoking "apt" only once while using a loop via squash_actions is deprecated. Instead of using a loop to supply multiple items and specifying `name: "{{ item }}"`, please use `name: '{{
apt_rc_packages.stdout_lines }}'` and remove the loop. This feature will be removed in version 2.11.