### PR TITLE
1.4.2 Add config path to aide.wrapper cronjob as suggested for CIS compliance

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -307,7 +307,7 @@ ubuntu1804cis_config_aide: true
 ubuntu1804cis_aide_cron:
   cron_user: root
   cron_file: /etc/crontab
-  aide_job: '/usr/bin/aide.wrapper --check'
+  aide_job: '/usr/bin/aide.wrapper --config /etc/aide/aide.conf --check'
   aide_minute: 0
   aide_hour: 5
   aide_day: '*'

--- a/tasks/section1.yml
+++ b/tasks/section1.yml
@@ -710,7 +710,7 @@
       path: "/boot/grub/grub.cfg"
       owner: root
       group: root
-      mode: 0600
+      mode: 0400
   when:
       - ansible_os_family == "Debian"
       - ubuntu1804cis_rule_1_5_1


### PR DESCRIPTION
According to the book they suggest to add the full config path to the cronjob. 