### PR TITLE
Updated 1.6.4 to include systemd-coredump

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -103,5 +103,7 @@
 - name: restart systemd-coredump
   become: true
   service:
-      name: systemd-coredump
+      name: systemd-coredump.socket
+      daemon_reload: true
+      enabled: true
       state: restarted

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -49,7 +49,7 @@
     path: "/boot/grub/grub.cfg"
     owner: root
     group: root
-    mode: 0600
+    mode: 0400
   when:
     - ansible_os_family == "Debian"
     - ubuntu1804cis_rule_1_4_1

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -99,3 +99,9 @@
       - not ubuntu1804cis_skip_for_travis
   tags:
       - skip_ansible_lint
+
+- name: restart systemd-coredump
+  become: true
+  service:
+      name: systemd-coredump
+      state: restarted

--- a/tasks/section1.yml
+++ b/tasks/section1.yml
@@ -1002,7 +1002,7 @@
       - ubuntu1804cis_rule_1_8_1_3
   tags:
       - level1
-      - notscored
+      - scored
       - patch
       - banner
       - rule_1.8.1.3

--- a/tasks/section1.yml
+++ b/tasks/section1.yml
@@ -888,6 +888,35 @@
       - patch
       - rule_1.6.4
 
+- name: "SCORED | 1.6.4 | PATCH | Ensure systemd-coredump is installed"
+  apt:
+    name: systemd-coredump
+    state: present
+  notify: restart systemd-coredump
+  when:
+      - ubuntu1804cis_rule_1_6_4
+  tags:
+      - level1
+      - scored
+      - patch
+      - rule_1.6.4      
+
+- name: "SCORED | 1.6.4 | PATCH | Ensure hard core 0 is set"
+  lineinfile:
+    dest: /etc/security/limits.conf
+    line: '* hard core 0'
+    regexp: '(^#\s*?\*\s+hard\s+core\s+[0-9]+)'
+    state: present
+    create: true
+  notify: restart systemd-coredump
+  when:
+      - ubuntu1804cis_rule_1_6_4
+  tags:
+      - level1
+      - scored
+      - patch
+      - rule_1.6.4 
+
 - name: "SCORED | 1.7.1.1 | PATCH | Ensure AppArmor is installed"
   apt:
       name: '{{ item }}'

--- a/tasks/section1.yml
+++ b/tasks/section1.yml
@@ -899,7 +899,7 @@
       - level1
       - scored
       - patch
-      - rule_1.6.4      
+      - rule_1.6.4
 
 - name: "SCORED | 1.6.4 | PATCH | Ensure hard core 0 is set"
   lineinfile:
@@ -915,7 +915,7 @@
       - level1
       - scored
       - patch
-      - rule_1.6.4 
+      - rule_1.6.4
 
 - name: "SCORED | 1.7.1.1 | PATCH | Ensure AppArmor is installed"
   apt:


### PR DESCRIPTION
(For whatever reason line 52 of handlers/main.yml is also coming along, which you merged already.) 