### PR TITLE
Update 5.1.8 Ensure at/cron is restricted to authorized users

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,9 +110,6 @@ ubuntu1804cis_aide_cron:
   aide_weekday: '*'  
 ```
 
-##### SELinux policy
-`ubuntu1804cis_selinux_pol: targeted`
-
 
 ##### Set to 'true' if X Windows is needed in your environment
 `ubuntu1804cis_xwindows_required: no`

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -351,9 +351,6 @@ ubuntu1804cis_aide_cron:
   aide_month: '*'
   aide_weekday: '*'
 
-# SELinux policy
-ubuntu1804cis_selinux_pol: targeted
-
 # Whether or not to run tasks related to auditing/patching the desktop environment
 ubuntu1804cis_gui: false
 
@@ -416,6 +413,9 @@ ubuntu1804cis_auditd:
 ubuntu1804cis_logrotate: "daily"
 
 ## Section 5 Vars
+ubuntu1804cis_at_allow_users: []
+ubuntu1804cis_cron_allow_users: []
+
 ubuntu1804cis_sshd:
   clientalivecountmax: 3
   clientaliveinterval: 300

--- a/tasks/section5.yml
+++ b/tasks/section5.yml
@@ -109,41 +109,31 @@
 
 - name: "SCORED | 5.1.8 | PATCH | Ensure at/cron is restricted to authorized users"
   block:
-      - name: "SCORED | 5.1.8 | PATCH | Ensure at/cron is restricted to authorized users"
+      - name: "SCORED | 5.1.8 | PATCH | Ensure at is restricted to authorized users"
         file:
             dest: /etc/at.deny
             state: absent
 
-      - name: "SCORED | 5.1.8 | PATCH | Check if at.allow exists"
-        stat:
-            path: "/etc/at.allow"
-        register: at_allow
-
-      - name: "SCORED | 5.1.8 | PATCH | Ensure at/cron is restricted to authorized users"
-        file:
+      - name: "SCORED | 5.1.8 | PATCH | Ensure at is restricted to authorized users"
+        template:
+            src: at.allow.j2
             dest: /etc/at.allow
-            state: '{{ "file" if  at_allow.stat.exists else "touch" }}'
             owner: root
             group: root
             mode: 0600
 
-      - name: "SCORED | 5.1.8 | PATCH | Ensure at/cron is restricted to authorized users"
+      - name: "SCORED | 5.1.8 | PATCH | Ensure cron is restricted to authorized users"
         file:
             dest: /etc/cron.deny
             state: absent
 
-      - name: "SCORED | 5.1.8 | PATCH | Check if cron.allow exists"
-        stat:
-            path: "/etc/cron.allow"
-        register: cron_allow
-
-      - name: "SCORED | 5.1.8 | PATCH | Ensure at/cron is restricted to authorized users"
-        file:
-            dest: /etc/cron.allow
-            state: '{{ "file" if  cron_allow.stat.exists else "touch" }}'
-            owner: root
-            group: root
-            mode: 0600
+      - name: "SCORED | 5.1.8 | PATCH | Ensure cron is restricted to authorized users"
+        template:
+          src: at.allow.j2
+          dest: /etc/at.allow
+          owner: root
+          group: root
+          mode: 0600
   when:
       - ubuntu1804cis_rule_5_1_8
   tags:

--- a/templates/at.allow.j2
+++ b/templates/at.allow.j2
@@ -1,0 +1,3 @@
+{% for user in ubuntu1804cis_at_allow_users %}
+{{ user }}
+{% endfor %}

--- a/templates/cron.allow.j2
+++ b/templates/cron.allow.j2
@@ -1,0 +1,3 @@
+{% for user in ubuntu1804cis_cron_allow_users %}
+{{ user }}
+{% endfor %}


### PR DESCRIPTION
By default there is no variable that control which user can use at or cron.
Which means only root can use cron or crontab, run `crontab -u user` under root will raise an error `The user <name> cannot use this program (crontab)`. So this PR is trying to

1. add vars `ubuntu1804cis_at_allow_users` and `ubuntu1804cis_cron_allow_users` to specific the allowed users.
2. prefer the whitelist than blacklist.
3. remove unused `ubuntu1804cis_selinux_pol`