### PR TITLE
Add missing tags to 1.4.1 State AIDE

### DIFF
--- a/tasks/section1.yml
+++ b/tasks/section1.yml
@@ -676,6 +676,12 @@
 - name: "SCORED | 1.4.1 | PATCH | Stat AIDE DB"
   stat: path=/var/lib/aide/aide.db
   register: aide_db
+  tags:
+      - level1
+      - scored
+      - aide
+      - patch
+      - rule_1.4.1
 
 - name: "SCORED | 1.4.1 | PATCH | Init AIDE | This may take a LONG time"
   command: /usr/sbin/aideinit


### PR DESCRIPTION
When running the playbook with ex. `tag level1`, it fails on task `SCORED | 1.4.1 | PATCH | Init AIDE | This may take a LONG time` due to its dependency on to the task `SCORED | 1.4.1 | PATCH | Stat AIDE DB`