### PR TITLE
Fix replace action

### DIFF
--- a/tasks/section1.yml
+++ b/tasks/section1.yml
@@ -980,7 +980,6 @@
             dest: /etc/default/grub
             regexp: '^(GRUB_CMDLINE_LINUX=(?!.*apparmor)\"[^\"]*)(\".*)'
             replace: '\1 apparmor=1 security=apparmor\2'
-            follow: true
         notify:
             - generate new grub config
 
@@ -989,7 +988,6 @@
             dest: /etc/default/grub
             regexp: '^(GRUB_CMDLINE_LINUX=(?!.*security)\"[^\"]*)(\".*)'
             replace: '\1 security=apparmor\2'
-            follow: true
         notify:
             - generate new grub config
   when:

--- a/tasks/section3.yml
+++ b/tasks/section3.yml
@@ -1035,7 +1035,6 @@
       dest: /etc/default/grub
       regexp: '^(GRUB_CMDLINE_LINUX=(?!.*ipv6.disable)\"[^\"]*)(\".*)'
       replace: '\1 ipv6.disable=1\2'
-      follow: true
   ignore_errors: true
   when:
       - ubuntu1804cis_rule_3_7

--- a/tasks/section4.yml
+++ b/tasks/section4.yml
@@ -34,7 +34,6 @@
       dest: /etc/default/grub
       regexp: '^(GRUB_CMDLINE_LINUX=(?!.*audit)\"[^\"]*)(\".*)'
       replace: '\1 audit=1\2'
-      follow: true
   notify:
       - generate new grub config
   when:
@@ -51,7 +50,6 @@
       dest: /etc/default/grub
       regexp: '^(GRUB_CMDLINE_LINUX=(?!.*audit_backlog_limit)\"[^\"]*)(\".*)'
       replace: '\1 audit_backlog_limit={{ ubuntu1804cis_auditd.backlog_limit }}\2'
-      follow: true
   ignore_errors: true
   notify:
       - generate new grub config


### PR DESCRIPTION
The replace action will get an error in ansible 2.10
```
TASK [/home/ubuntu/roles/ubuntu1804 : SCORED | 1.7.1.2 | PATCH | Ensure AppArmor is enabled in the bootloader configuration] ***
fatal: [localhost]: FAILED! => {"changed": false, "msg": "Unsupported parameters for (replace) module: follow Supported parameters include: after, attributes, backup, before, encoding, group, mode, owner, path, regexp, replace, selevel, serole, setype, seuser, unsafe_writes, validate"}
```

According to https://docs.ansible.com/ansible/latest/collections/ansible/builtin/replace_module.html, `follow` should be removed
> Option follow has been removed in Ansible 2.5, because this module modifies the contents of the file so follow=no doesn’t make sense.